### PR TITLE
Remove pull request trigger for GH-pages deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
I think we'd only want to deploy the docs when something is actually pushed to main?