### PR TITLE
Bugfix/26 type exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+types
 
 # Editor directories and files
 .vscode/*

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "test": "echo \"Error: no test specified\" && exit 1",
         "link": "npm link && cd docs && npm link @usace-watermanagement/groundwork-water",
         "build": "npm run build-lib",
-        "build-lib": "vite build --mode lib && npm run link",
+        "build-lib": "tsc && vite build --mode lib && npm run link",
         "build-docs": "cd docs && vite build",
         "build-docs-prod": "cd docs && vite build",
         "deploy": "gh-pages -d dist",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,16 @@
     "description": "A library of react components for use with USACE Water Management Webpages",
     "main": "./dist/groundwork-water.umd.cjs",
     "module": "./dist/groundwork-water.es.js",
+    "types": "types/lib/index.d.ts",
     "files": [
-        "dist"
+        "dist",
+        "types"
     ],
     "exports": {
         ".": {
             "import": "./dist/groundwork-water.es.js",
             "require": "./dist/groundwork-water.umd.cjs",
-            "types": "./dist/index.d.ts"
+            "types": "./types/lib/index.d.ts"
         },
         "./dist/*.css": {
             "import": "./dist/*.css",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,12 @@
   "compilerOptions": {
     "allowJs": true,
     "declaration": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": true,
+    "rootDir": ".",
+    "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "noEmit": true,
     "skipLibCheck": true,
     "target": "ES6",
 
@@ -14,5 +17,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["lib", "vite.config.ts"]
+  "include": ["lib", "declarejs.d.ts"],
+  "exclude": ["dist", "docs"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig(({ mode }) => {
             plugins: [react(), tailwindcss()],
             publicDir: false,
             build: {
+                minify: false,
                 lib: {
                     name: "GroundworkWater",
                     fileName: (format) => `groundwork-water.${format}.js`,


### PR DESCRIPTION
- Turn on type exporting in tsconfig
- Run tsc as part of build
- Add types directory to npm exports
- Un-minify vite bundle