### PR TITLE
Incorporate tailwind and groundwork

### DIFF
--- a/declarejs.d.ts
+++ b/declarejs.d.ts
@@ -1,0 +1,1 @@
+declare module "@usace/groundwork";

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@usace-watermanagement/groundwork-water": "^2.2.0",
-                "@usace/groundwork": "^3.0.1",
+                "@usace/groundwork": "^3.1.0",
                 "clsx": "^2.1.0",
                 "cwmsjs": "^1.15.0",
                 "dayjs": "^1.11.11",
@@ -1259,17 +1259,16 @@
             }
         },
         "node_modules/@usace/groundwork": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@usace/groundwork/-/groundwork-3.0.1.tgz",
-            "integrity": "sha512-esW+Sxomaugf706g0UHi4UJby2I1nfQQvL+1anZB4xl94qTIUl+OeHgAUtmlGqYC1wN8XVuJ8pQQwpJbDVJ32g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@usace/groundwork/-/groundwork-3.1.0.tgz",
+            "integrity": "sha512-JDHJ0cSGocofXSKCbHIKUQ+37v3PxfhNCt36swaVAJxNtjpgzlOtGzL68zBlldCVZLF2RqkWn/+uqcBhf0UTDQ==",
             "dependencies": {
                 "@headlessui/react": "^2.0.0-alpha.4",
                 "internal-nav-helper": "^3.1.0",
                 "react-icons": "^5.0.1",
                 "redux-bundler": "^28.1.0",
                 "redux-bundler-hook": "^1.0.3",
-                "redux-bundler-react": "^1.2.0",
-                "tailwind-merge": "^2.3.0"
+                "redux-bundler-react": "^1.2.0"
             },
             "peerDependencies": {
                 "react": "^18.2.0",
@@ -5221,15 +5220,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
             "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-        },
-        "node_modules/tailwind-merge": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.2.tgz",
-            "integrity": "sha512-kjEBm+pvD+6eAwzJL2Bi+02/9LFLal1Gs61+QB7HvTfQQ0aXwC5LGT8PEt1gS0CWKktKe6ysPTAy3cBC5MeiIg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/dcastil"
-            }
         },
         "node_modules/tailwindcss": {
             "version": "3.4.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@usace-watermanagement/groundwork-water": "^2.2.0",
-        "@usace/groundwork": "^3.0.1",
+        "@usace/groundwork": "^3.1.0",
         "clsx": "^2.1.0",
         "cwmsjs": "^1.15.0",
         "dayjs": "^1.11.11",

--- a/docs/src/App.jsx
+++ b/docs/src/App.jsx
@@ -8,7 +8,7 @@ import { getNavHelper } from "internal-nav-helper";
 import { useConnect } from "redux-bundler-hook";
 import links from "./nav-links";
 import { FaGithub } from "react-icons/fa";
-import "@usace/groundwork/dist/style.css";
+import "@usace-watermanagement/groundwork-water/dist/style.css";
 import DevWarning from "./components/DevWarning";
 const version = import.meta.env.PKG_VERSION;
 

--- a/docs/src/components/QueryClientWarning.jsx
+++ b/docs/src/components/QueryClientWarning.jsx
@@ -3,12 +3,12 @@ import { IoWarning } from "react-icons/io5";
 
 const QueryClientWarning = () => {
   return (
-    <Card className="gw-my-2">
-      <IoWarning className="gw-float-start gw-text-2xl gw-mr-2 gw-text-gray-700" />
+    <Card className="my-2 flex">
+      <IoWarning size="1.5rem" className="flex-none mr-2 text-gray-700" />
       <Text>
         Use of the groundwork data hooks requires that your application be
         wrapped in a QueryClientProvider. Refer to the{" "}
-        <a href="/docs/react-query" className="gw-underline">
+        <a href="/docs/react-query" className="underline">
           Getting Started - React-Query
         </a>{" "}
         page.

--- a/docs/src/pages/docs/add-components/index.jsx
+++ b/docs/src/pages/docs/add-components/index.jsx
@@ -63,18 +63,24 @@ export default function Docs() {
 
         <H4>Installation</H4>
         <Code className="gw-block gw-p-1 gw-px-2" language="bash">
-          npm install @usace/groundwork
+          {`npm install @usace-watermanagement/groundwork-water`}
         </Code>
         <H4>Import Components and Styles</H4>
-        <Code className="gw-block gw-p-1 gw-px-2" language="bash">
-          {`import { SiteWrapper } from "@usace/groundwork"`}
+        <Code className="gw-block gw-p-1 gw-px-2" language="jsx">
+          {`import { TSPlot } from "@usace-watermanagement/groundwork-water"`}
         </Code>
-        <Code className="gw-block gw-p-1 gw-px-2" language="bash">
-          import "@usace/groundwork/dist/style.css"
+        <Code className="gw-block gw-p-1 gw-px-2" language="jsx">
+          {`import "@usace-watermanagement/groundwork-water/dist/style.css";`}
         </Code>
         <Text>
-          Make sure to import style.css from Groundwork into your top-level
-          component (i.e. App.jsx), then go build stuff with the components
+          Make sure to import style.css from Groundwork-Water into your
+          top-level component (i.e. App.jsx), then go build stuff with the
+          components!
+        </Text>
+        <br />
+        <Text>
+          Note: The Groundwork-Water styles include all of the base Groundwork
+          styles.
         </Text>
       </UsaceBox>
     </DocsPage>

--- a/docs/src/pages/docs/add-components/index.jsx
+++ b/docs/src/pages/docs/add-components/index.jsx
@@ -7,10 +7,10 @@ export default function Docs() {
   return (
     <DocsPage
       prevUrl={"/docs/quick-start"}
-      nextUrl="/docs/plots"
+      nextUrl="/docs/react-query"
       middleText="Add Components"
       prevText="Return to Quick Start"
-      nextText="Go to Plots Page"
+      nextText="Go to React Query Page"
     >
       <UsaceBox title="Add Components">
         <H4>Project Setup</H4>

--- a/docs/src/pages/docs/quick-start/index.jsx
+++ b/docs/src/pages/docs/quick-start/index.jsx
@@ -6,11 +6,9 @@ import DocsPage from "../_docs-wrapper";
 export default function Docs() {
   return (
     <DocsPage
-      nextUrl="/docs/react-query"
-      prevUrl="/docs/quick-start"
+      nextUrl="/docs/add-components"
       middleText="Quick Start"
       nextText="Go to Add Components Page"
-      prevText="Return to Quick Start"
     >
       <div className="gw-mt-3 gw-mb-3">
         <Text>

--- a/lib/components/data/maps/GageMap.jsx
+++ b/lib/components/data/maps/GageMap.jsx
@@ -31,7 +31,7 @@ function GageMap({className}) {
     }, []);
 
     return (
-      <div id="map" className={`map-container w-full ${className}`} ref={mapElement} />
+      <div id="map" className={`map-container gww-w-full ${className}`} ref={mapElement} />
     //   className="map-container absolute top-0 bottom-0 w-96" 
     );
 }

--- a/lib/components/data/maps/GageMap.jsx
+++ b/lib/components/data/maps/GageMap.jsx
@@ -1,39 +1,44 @@
 /* eslint-disable react/prop-types */
 // MapComponent.js
-import { useEffect, useRef } from 'react';
-import TileLayer from 'ol/layer/Tile';
+import { useEffect, useRef } from "react";
+import TileLayer from "ol/layer/Tile";
 
-import Map from 'ol/Map';
-import View from 'ol/View';
-import Overlay from 'ol/Overlay';
-import OSM from 'ol/source/OSM';
-import 'ol/ol.css';
+import Map from "ol/Map";
+import View from "ol/View";
+import Overlay from "ol/Overlay";
+import OSM from "ol/source/OSM";
+import "ol/ol.css";
 
-import "../../../css/map.css"
+import "../../../css/map.css";
+import { gwMerge } from "@usace/groundwork";
 
-function GageMap({className}) {
-    const mapElement = useRef()
-    useEffect(() => {
-        const osmLayer = new TileLayer({
-            preload: Infinity,
-            source: new OSM(),
-        })
+function GageMap({ className }) {
+  const mapElement = useRef();
+  useEffect(() => {
+    const osmLayer = new TileLayer({
+      preload: Infinity,
+      source: new OSM(),
+    });
 
-        const map = new Map({
-            target: mapElement.current,
-            layers: [osmLayer],
-            view: new View({
-                center: [0, 0],
-                zoom: 0,
-              }),
-          });
-      return () => map.setTarget(null)
-    }, []);
+    const map = new Map({
+      target: mapElement.current,
+      layers: [osmLayer],
+      view: new View({
+        center: [0, 0],
+        zoom: 0,
+      }),
+    });
+    return () => map.setTarget(null);
+  }, []);
 
-    return (
-      <div id="map" className={`map-container gww-w-full ${className}`} ref={mapElement} />
-    //   className="map-container absolute top-0 bottom-0 w-96" 
-    );
+  return (
+    <div
+      id="map"
+      className={gwMerge("map-container gww-w-full", className)}
+      ref={mapElement}
+    />
+    //   className="map-container absolute top-0 bottom-0 w-96"
+  );
 }
 
 export default GageMap;

--- a/lib/components/data/plots/CWMSPlot.jsx
+++ b/lib/components/data/plots/CWMSPlot.jsx
@@ -180,13 +180,13 @@ export default function CWMSPlot({
 
   return (
     <div
-      className={`h-full w-full ${className}`}
+      className={`gww-h-full gww-w-full ${className}`}
       style={{ height: plotHeight }}
     >
       <div
         ref={plotElement}
         id="plot"
-        className="h-full w-full"
+        className="gww-h-full gww-w-full"
         style={{ height: plotHeight }}
       >
         {isLoading ? (

--- a/lib/components/data/plots/CWMSPlot.jsx
+++ b/lib/components/data/plots/CWMSPlot.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Configuration, TimeSeriesApi } from "cwmsjs";
 import Plotly from "plotly.js-basic-dist";
 import dayjs from "dayjs";
+import { gwMerge } from "@usace/groundwork";
 
 const config_v2 = new Configuration({
   headers: {
@@ -180,7 +181,7 @@ export default function CWMSPlot({
 
   return (
     <div
-      className={`gww-h-full gww-w-full ${className}`}
+      className={gwMerge("gww-h-full gww-w-full", className)}
       style={{ height: plotHeight }}
     >
       <div

--- a/lib/components/data/plots/TSPlot.jsx
+++ b/lib/components/data/plots/TSPlot.jsx
@@ -70,7 +70,7 @@ const TSPlot = ({
     <div
       ref={plotContainerRef}
       title={title}
-      className="h-full w-full"
+      className="gww-h-full gww-w-full"
       style={{ width: "100%", height: plotHeight }}
       {...props}
     ></div>

--- a/lib/components/display/Table.jsx
+++ b/lib/components/display/Table.jsx
@@ -33,46 +33,46 @@ export default function Table({
   }, [content, order]);
 
   return (
-    <div className="gw-px-4 gw-sm:px-6 gw-lg:px-8">
-      <div className="gw-sm:flex gw-sm:items-center">
-        <div className="gw-sm:flex-auto">
+    <div className="gww-px-4 gww-sm:px-6 gww-lg:px-8">
+      <div className="gww-sm:flex gww-sm:items-center">
+        <div className="gww-sm:flex-auto">
           {title && (
-            <h1 className="gw-text-base gw-font-semibold gw-leading-6 gw-text-gray-900">
+            <h1 className="gww-text-base gww-font-semibold gww-leading-6 gww-text-gray-900">
               {title}
             </h1>
           )}
           {subTitle && (
-            <p className="gw-mt-2 gw-text-sm gw-text-gray-700">{subTitle}</p>
+            <p className="gww-mt-2 gww-text-sm gww-text-gray-700">{subTitle}</p>
           )}
         </div>
       </div>
-      <div className="gw-mt-8 gw-flow-root">
-        <div className="gw--mx-4 gw--my-2 gw-overflow-x-auto gw-sm:-mx-6 gw-lg:-mx-8">
-          <div className="gw-inline-block gw-min-w-full gw-py-2 gw-align-middle gw-sm:px-6 gw-lg:px-8">
-            <table className="gw-min-w-full gw-divide-y gw-divide-gray-300">
+      <div className="gww-mt-8 gww-flow-root">
+        <div className="gww--mx-4 gww--my-2 gww-overflow-x-auto gww-sm:-mx-6 gww-lg:-mx-8">
+          <div className="gww-inline-block gww-min-w-full gww-py-2 gww-align-middle gww-sm:px-6 gww-lg:px-8">
+            <table className="gww-min-w-full gww-divide-y gww-divide-gray-300">
               <thead>
                 <tr>
                   {heading.map((heading) => (
                     <th
                       key={heading}
                       scope="col"
-                      className="gw-py-3.5 gw-pl-4 gw-pr-3 gw-text-left gw-text-sm gw-font-semibold gw-text-gray-900 gw-sm:pl-3"
+                      className="gww-py-3.5 gww-pl-4 gww-pr-3 gww-text-left gww-text-sm gww-font-semibold gww-text-gray-900 gww-sm:pl-3"
                     >
                       {heading}
                     </th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="gw-bg-white">
+              <tbody className="gww-bg-white">
                 {sortedContent.map((dataPoint) => (
-                  <tr key={dataPoint[0]} className="gw-even:bg-gray-50">
-                    <td className="gw-whitespace-nowrap gw-py-4 gw-pl-4 gw-pr-3 gw-text-sm gw-font-medium gw-text-gray-900 gw-sm:pl-3">
+                  <tr key={dataPoint[0]} className="gww-even:bg-gray-50">
+                    <td className="gww-whitespace-nowrap gww-py-4 gww-pl-4 gww-pr-3 gww-text-sm gww-font-medium gww-text-gray-900 gww-sm:pl-3">
                       {dayjs(dataPoint[0]).format(dateFormat)}
                     </td>
-                    <td className="gw-whitespace-nowrap gw-px-3 gw-py-4 gw-text-sm gw-text-gray-500">
+                    <td className="gww-whitespace-nowrap gww-px-3 gww-py-4 gww-text-sm gww-text-gray-500">
                       {formatNumber(dataPoint[1], precision)}
                     </td>
-                    <td className="gw-whitespace-nowrap gw-px-3 gw-py-4 gw-text-sm gw-text-gray-500">
+                    <td className="gww-whitespace-nowrap gww-px-3 gww-py-4 gww-text-sm gww-text-gray-500">
                       {dataPoint[2]}
                     </td>
                   </tr>

--- a/lib/css/tailwind.css
+++ b/lib/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -1,3 +1,6 @@
+// Bundle tailwind
+import "./css/tailwind.css";
+
 // Import components
 import TSPlot from "./components/data/plots/TSPlot";
 import TSTable from "./components/data/tables/TSTable";

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -1,6 +1,9 @@
 // Bundle tailwind
 import "./css/tailwind.css";
 
+// Bundle groundwork-water styles
+import "@usace/groundwork/dist/style.css";
+
 // Import components
 import TSPlot from "./components/data/plots/TSPlot";
 import TSTable from "./components/data/tables/TSTable";

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "@typescript-eslint/eslint-plugin": "^8.0.0",
                 "@typescript-eslint/parser": "^8.0.0",
                 "@vitejs/plugin-react": "^4.3.1",
+                "autoprefixer": "^10.4.20",
                 "eslint": "^8.57.0",
                 "eslint-plugin-react": "^7.34.1",
                 "eslint-plugin-react-hooks": "^4.6.0",
@@ -2380,6 +2381,43 @@
             "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
             "dev": true
         },
+        "node_modules/autoprefixer": {
+            "version": "10.4.20",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+            "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
+                "browserslist": "^4.23.3",
+                "caniuse-lite": "^1.0.30001646",
+                "fraction.js": "^4.3.7",
+                "normalize-range": "^0.1.2",
+                "picocolors": "^1.0.1",
+                "postcss-value-parser": "^4.2.0"
+            },
+            "bin": {
+                "autoprefixer": "bin/autoprefixer"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2436,9 +2474,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
             "dev": true,
             "funding": [
                 {
@@ -2455,10 +2493,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001629",
-                "electron-to-chromium": "^1.4.796",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.16"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2513,9 +2551,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001636",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
+            "version": "1.0.30001660",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+            "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
             "dev": true,
             "funding": [
                 {
@@ -2920,9 +2958,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.804",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.804.tgz",
-            "integrity": "sha512-gXMMs2m7aUTdZpORQAvMCyH0JHywSpZxjblSc/C81aDr34jh0hmpplTFcM4AYrYALVmiVT/r63oA3tEG1BPVRw==",
+            "version": "1.5.25",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz",
+            "integrity": "sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==",
             "dev": true
         },
         "node_modules/email-addresses": {
@@ -3146,9 +3184,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -3847,6 +3885,19 @@
             "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
             "engines": {
                 "node": ">=0.4.x"
+            }
+        },
+        "node_modules/fraction.js": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "type": "patreon",
+                "url": "https://github.com/sponsors/rawify"
             }
         },
         "node_modules/fs-extra": {
@@ -5101,15 +5152,24 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
             "dev": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -6818,9 +6878,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
                 "vite-plugin-dts": "^4.0.0-beta.2"
             },
             "peerDependencies": {
-                "@tanstack/react-query": "^5.51.23"
+                "@tanstack/react-query": "^5.51.23",
+                "@usace/groundwork": "^3.1.0"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -870,6 +871,78 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@floating-ui/core": {
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+            "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+            "peer": true,
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.8"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.6.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+            "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
+            "peer": true,
+            "dependencies": {
+                "@floating-ui/core": "^1.6.0",
+                "@floating-ui/utils": "^0.2.8"
+            }
+        },
+        "node_modules/@floating-ui/react": {
+            "version": "0.26.24",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.24.tgz",
+            "integrity": "sha512-2ly0pCkZIGEQUq5H8bBK0XJmc1xIK/RM3tvVzY3GBER7IOD1UgmC2Y2tjj4AuS+TC+vTE1KJv2053290jua0Sw==",
+            "peer": true,
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.1.2",
+                "@floating-ui/utils": "^0.2.8",
+                "tabbable": "^6.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+            "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+            "peer": true,
+            "dependencies": {
+                "@floating-ui/dom": "^1.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
+            "peer": true
+        },
+        "node_modules/@headlessui/react": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.8.tgz",
+            "integrity": "sha512-uajqVkAcVG/wHwG9Fh5PFMcFpf2VxM4vNRNKxRjuK009kePVur8LkuuygHfIE+2uZ7z7GnlTtYsyUe6glPpTLg==",
+            "peer": true,
+            "dependencies": {
+                "@floating-ui/react": "^0.26.16",
+                "@react-aria/focus": "^3.17.1",
+                "@react-aria/interactions": "^3.21.3",
+                "@tanstack/react-virtual": "^3.8.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^18",
+                "react-dom": "^18"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.11.14",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1141,6 +1214,89 @@
             "optional": true,
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@react-aria/focus": {
+            "version": "3.18.2",
+            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.18.2.tgz",
+            "integrity": "sha512-Jc/IY+StjA3uqN73o6txKQ527RFU7gnG5crEl5Xy3V+gbYp2O5L3ezAo/E0Ipi2cyMbG6T5Iit1IDs7hcGu8aw==",
+            "peer": true,
+            "dependencies": {
+                "@react-aria/interactions": "^3.22.2",
+                "@react-aria/utils": "^3.25.2",
+                "@react-types/shared": "^3.24.1",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@react-aria/interactions": {
+            "version": "3.22.2",
+            "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.22.2.tgz",
+            "integrity": "sha512-xE/77fRVSlqHp2sfkrMeNLrqf2amF/RyuAS6T5oDJemRSgYM3UoxTbWjucPhfnoW7r32pFPHHgz4lbdX8xqD/g==",
+            "peer": true,
+            "dependencies": {
+                "@react-aria/ssr": "^3.9.5",
+                "@react-aria/utils": "^3.25.2",
+                "@react-types/shared": "^3.24.1",
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@react-aria/ssr": {
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.5.tgz",
+            "integrity": "sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==",
+            "peer": true,
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@react-aria/utils": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.25.2.tgz",
+            "integrity": "sha512-GdIvG8GBJJZygB4L2QJP1Gabyn2mjFsha73I2wSe+o4DYeGWoJiMZRM06PyTIxLH4S7Sn7eVDtsSBfkc2VY/NA==",
+            "peer": true,
+            "dependencies": {
+                "@react-aria/ssr": "^3.9.5",
+                "@react-stately/utils": "^3.10.3",
+                "@react-types/shared": "^3.24.1",
+                "@swc/helpers": "^0.5.0",
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@react-stately/utils": {
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.3.tgz",
+            "integrity": "sha512-moClv7MlVSHpbYtQIkm0Cx+on8Pgt1XqtPx6fy9rQFb2DNc9u1G3AUVnqA17buOkH1vLxAtX4MedlxMWyRCYYA==",
+            "peer": true,
+            "dependencies": {
+                "@swc/helpers": "^0.5.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@react-types/shared": {
+            "version": "3.24.1",
+            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.24.1.tgz",
+            "integrity": "sha512-AUQeGYEm/zDTN6zLzdXolDxz3Jk5dDL7f506F07U8tBwxNNI3WRdhU84G0/AaFikOZzDXhOZDr3MhQMzyE7Ydw==",
+            "peer": true,
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@rollup/pluginutils": {
@@ -1551,6 +1707,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.13",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
+            "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@tanstack/query-core": {
             "version": "5.56.2",
             "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.56.2.tgz",
@@ -1575,6 +1740,33 @@
             },
             "peerDependencies": {
                 "react": "^18 || ^19"
+            }
+        },
+        "node_modules/@tanstack/react-virtual": {
+            "version": "3.10.8",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz",
+            "integrity": "sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==",
+            "peer": true,
+            "dependencies": {
+                "@tanstack/virtual-core": "3.10.8"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.10.8",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz",
+            "integrity": "sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==",
+            "peer": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@types/argparse": {
@@ -1941,6 +2133,24 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
+        },
+        "node_modules/@usace/groundwork": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@usace/groundwork/-/groundwork-3.1.0.tgz",
+            "integrity": "sha512-JDHJ0cSGocofXSKCbHIKUQ+37v3PxfhNCt36swaVAJxNtjpgzlOtGzL68zBlldCVZLF2RqkWn/+uqcBhf0UTDQ==",
+            "peer": true,
+            "dependencies": {
+                "@headlessui/react": "^2.0.0-alpha.4",
+                "internal-nav-helper": "^3.1.0",
+                "react-icons": "^5.0.1",
+                "redux-bundler": "^28.1.0",
+                "redux-bundler-hook": "^1.0.3",
+                "redux-bundler-react": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
+            }
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.3.1",
@@ -4345,6 +4555,12 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "node_modules/internal-nav-helper": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/internal-nav-helper/-/internal-nav-helper-3.1.0.tgz",
+            "integrity": "sha512-05fxcHzJqH2ObzfykSSO/WREvMQJtK+O1jhVKcPev0ovlMnJ5vNv0I0EudJx/iQK93/96hFfjjU2tvNQ1h580g==",
+            "peer": true
+        },
         "node_modules/internal-slot": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -5867,6 +6083,15 @@
                 "react": "^18.3.1"
             }
         },
+        "node_modules/react-icons": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+            "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+            "peer": true,
+            "peerDependencies": {
+                "react": "*"
+            }
+        },
         "node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5916,6 +6141,32 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/redux-bundler": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/redux-bundler/-/redux-bundler-28.1.0.tgz",
+            "integrity": "sha512-dbq0J0Sm0ctK9ZUh73JR/6J937qzNvkKEHXtHv7p2Hl/9sS+xyRQReWjuju8LHopYFiG+U0Lg9XZM1hPp1WkHg==",
+            "peer": true
+        },
+        "node_modules/redux-bundler-hook": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/redux-bundler-hook/-/redux-bundler-hook-1.0.3.tgz",
+            "integrity": "sha512-QDeGuR0hOXjURnCxHlYfOvD46KwqcZEMRaxdo06FQKMQO+o6yRHTyBN3iZLhgQSoM0VEyjLmGrulfBm6ciOBnQ==",
+            "peer": true,
+            "peerDependencies": {
+                "react": ">=16.8.6",
+                "redux-bundler": "*"
+            }
+        },
+        "node_modules/redux-bundler-react": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redux-bundler-react/-/redux-bundler-react-1.2.0.tgz",
+            "integrity": "sha512-vyZMnt+uXyhihoZu8CyEQOfJIbhvl+yhvrL+WB+yo6kckYPBXOfXNssiviHrOb49BSWb30BRGQ6HX/ydk39Tvg==",
+            "peer": true,
+            "peerDependencies": {
+                "react": "*",
+                "redux-bundler": "*"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -6586,6 +6837,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/tabbable": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+            "peer": true
+        },
         "node_modules/tailwindcss": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
@@ -6728,6 +6985,12 @@
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
             "dev": true
+        },
+        "node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,6 @@
                 "dayjs": "^1.11.11",
                 "ol": "^10.0.0",
                 "plotly.js-basic-dist": "^2.33.0",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
                 "react-syntax-highlighter": "^15.5.0"
             },
             "devDependencies": {
@@ -39,7 +37,9 @@
             },
             "peerDependencies": {
                 "@tanstack/react-query": "^5.51.23",
-                "@usace/groundwork": "^3.1.0"
+                "@usace/groundwork": "^3.1.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -6064,6 +6064,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -6075,6 +6076,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -6382,6 +6384,7 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "vite-plugin-dts": "^4.0.0-beta.2"
     },
     "peerDependencies": {
-        "@tanstack/react-query": "^5.51.23"
+        "@tanstack/react-query": "^5.51.23",
+        "@usace/groundwork": "^3.1.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "autoprefixer": "^10.4.20",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,6 @@
         "dayjs": "^1.11.11",
         "ol": "^10.0.0",
         "plotly.js-basic-dist": "^2.33.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
         "react-syntax-highlighter": "^15.5.0"
     },
     "devDependencies": {
@@ -78,6 +76,8 @@
     },
     "peerDependencies": {
         "@tanstack/react-query": "^5.51.23",
-        "@usace/groundwork": "^3.1.0"
+        "@usace/groundwork": "^3.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
     }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,29 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./lib/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {
+      gridTemplateRows: {
+        "1fr-auto": "1fr auto",
+      },
+      fontFamily: {
+        usace: ["Roboto", "Arial", "Helvetica", "sans-serif"],
+      },
+      colors: {
+        "nav-light-gray": "#d0d0d0",
+        "nav-gray": "hsla(0, 0%, 80%, 0.9)",
+        "nav-translucent-gray": "hsla(0, 0%, 100%, 0.2)",
+        "nav-black": "#18181b",
+        "nav-dark-gray": "rgba(51,51,51,.95)",
+        "usace-box-light-gray": "#ededed",
+        "usace-box-red": "#de1e2e",
+        "footer-black": "#1b1b1b",
+        "footer-gray": "#333",
+        "footer-light-gray": "#ccc",
+        "usace-black": "#18181b",
+      },
+    },
+  },
+  darkMode: "class",
+  plugins: [],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./lib/**/*.{js,ts,jsx,tsx}"],
+  prefix: "gww-",
   theme: {
     extend: {
       gridTemplateRows: {


### PR DESCRIPTION
@krowvin Figured you might want to take a glance at this before it gets merged since it's a fairly big/foundational change.  Basically attaches tailwind to the library and includes base Groundwork as a peer dependency.

For tailwind, I think using a new prefix (e.g. gww-) is probably the "correct" way to do things but it was going to open up a big can of worms className-conflict-wise.  I swapped to the easy way out of just duplicating the Groundwork "gw-" prefix, which seems a little... wrong... but I'm content to sweep it under the rug until it actually manifests as a bug for someone.  It worked as expected in the testing I did, but there may be some edge cases out there that I haven't come across.