### PR TITLE
cwmsjs v2

### DIFF
--- a/lib/components/data/cards/CdaLatestValueCard.tsx
+++ b/lib/components/data/cards/CdaLatestValueCard.tsx
@@ -48,7 +48,6 @@ const CdaLatestValueCard = ({
           </span>
         ) : data ? (
           <CardValue
-            // @ts-expect-error cwmsjs TimeSeries values typing is erroneous
             value={data.value}
             units={data.units ?? ""}
             digits={digits}
@@ -64,7 +63,6 @@ const CdaLatestValueCard = ({
           <span>No data found</span>
         ) : data ? (
           <>
-            {/* @ts-expect-error cwmsjs TimeSeries values typing is erroneous */}
             <CardTimestamp datetime={new Date(data.datetime)} />
             {/* {change ? <Parameter24hrChange change={change} /> : customBotRight} */}
           </>

--- a/lib/components/data/hooks/useCdaCatalog.ts
+++ b/lib/components/data/hooks/useCdaCatalog.ts
@@ -1,13 +1,9 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
-import {
-  Catalog,
-  CatalogApi,
-  GetCwmsDataCatalogWithDatasetRequest,
-} from "cwmsjs";
+import { Catalog, CatalogApi, GetCatalogWithDatasetRequest } from "cwmsjs";
 import { useCdaConfig } from "../helpers/cda";
 
 interface UseCdaCatalogParams {
-  cdaParams: GetCwmsDataCatalogWithDatasetRequest;
+  cdaParams: GetCatalogWithDatasetRequest;
   cdaUrl?: string;
   queryOptions?: Partial<UseQueryOptions<Catalog>>;
 }
@@ -22,7 +18,7 @@ const useCdaCatalog = ({
 
   return useQuery({
     queryKey: ["cda", "catalog", cdaParams.like],
-    queryFn: async () => catalogApi.getCwmsDataCatalogWithDataset(cdaParams),
+    queryFn: async () => catalogApi.getCatalogWithDataset(cdaParams),
     ...queryOptions,
   });
 };

--- a/lib/components/data/hooks/useCdaLocation.ts
+++ b/lib/components/data/hooks/useCdaLocation.ts
@@ -1,13 +1,13 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import {
-  GetCwmsDataLocationsWithLocationIdRequest,
+  GetLocationsWithLocationIdRequest,
   Location,
   LocationsApi,
 } from "cwmsjs";
 import { useCdaConfig } from "../helpers/cda";
 
 interface useCdaLocationParams {
-  cdaParams: GetCwmsDataLocationsWithLocationIdRequest;
+  cdaParams: GetLocationsWithLocationIdRequest;
   cdaUrl?: string;
   queryOptions?: Partial<UseQueryOptions<Location>>;
 }
@@ -22,8 +22,7 @@ const useCdaLocation = ({
 
   return useQuery({
     queryKey: ["cda", "location", cdaParams.locationId],
-    queryFn: async () =>
-      locationsApi.getCwmsDataLocationsWithLocationId(cdaParams),
+    queryFn: async () => locationsApi.getLocationsWithLocationId(cdaParams),
     ...queryOptions,
   });
 };

--- a/lib/components/data/hooks/useCdaTimeSeries.ts
+++ b/lib/components/data/hooks/useCdaTimeSeries.ts
@@ -1,13 +1,9 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
-import {
-  GetCwmsDataTimeseriesRequest,
-  TimeSeries,
-  TimeSeriesApi,
-} from "cwmsjs";
+import { GetTimeSeriesRequest, TimeSeries, TimeSeriesApi } from "cwmsjs";
 import { useCdaConfig } from "../helpers/cda";
 
 interface useCdaTimeSeriesParams {
-  cdaParams: GetCwmsDataTimeseriesRequest;
+  cdaParams: GetTimeSeriesRequest;
   cdaUrl?: string;
   queryOptions?: Partial<UseQueryOptions<TimeSeries>>;
 }
@@ -22,7 +18,7 @@ const useCdaTimeSeries = ({
 
   return useQuery({
     queryKey: ["cda", "timeseries", cdaParams.name],
-    queryFn: async () => timeseriesApi.getCwmsDataTimeseries(cdaParams),
+    queryFn: async () => timeseriesApi.getTimeSeries(cdaParams),
     ...queryOptions,
   });
 };

--- a/lib/components/data/hooks/useCdaTimeSeriesGroup.ts
+++ b/lib/components/data/hooks/useCdaTimeSeriesGroup.ts
@@ -1,13 +1,13 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import {
-  GetCwmsDataTimeseriesGroupWithGroupIdRequest,
+  GetTimeSeriesGroupWithGroupIdRequest,
   TimeSeriesGroup,
-  TimeseriesGroupsApi,
+  TimeSeriesGroupsApi,
 } from "cwmsjs";
 import { useCdaConfig } from "../helpers/cda";
 
 interface useCdaTimeSeriesGroupParams {
-  cdaParams: GetCwmsDataTimeseriesGroupWithGroupIdRequest;
+  cdaParams: GetTimeSeriesGroupWithGroupIdRequest;
   cdaUrl?: string;
   queryOptions?: Partial<UseQueryOptions<TimeSeriesGroup>>;
 }
@@ -18,12 +18,12 @@ const useCdaTimeSeriesGroup = ({
   queryOptions,
 }: useCdaTimeSeriesGroupParams) => {
   const config = useCdaConfig("v1", cdaUrl);
-  const timeseriesGroupsApi = new TimeseriesGroupsApi(config);
+  const timeseriesGroupsApi = new TimeSeriesGroupsApi(config);
 
   return useQuery({
     queryKey: ["cda", "timeseries-group", cdaParams.groupId],
     queryFn: async () =>
-      timeseriesGroupsApi.getCwmsDataTimeseriesGroupWithGroupId(cdaParams),
+      timeseriesGroupsApi.getTimeSeriesGroupWithGroupId(cdaParams),
     ...queryOptions,
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.4.0",
             "license": "MIT",
             "dependencies": {
-                "cwmsjs": "^1.15.0",
+                "cwmsjs": "^2.1.5-2024.11.14",
                 "dayjs": "^1.11.11",
                 "ol": "^10.0.0",
                 "plotly.js-basic-dist": "^2.33.0",
@@ -2426,9 +2426,9 @@
             "dev": true
         },
         "node_modules/cwmsjs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-1.15.0.tgz",
-            "integrity": "sha512-HmIX9oNXEWwvT1FU5i0fe4rJthm6yOIuiaGozQt47ydB3hCpRLSbUd6eJytgIbX22A2gS5ErDPozSTbEgDeYuw=="
+            "version": "2.1.5-2024.11.14",
+            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-2.1.5-2024.11.14.tgz",
+            "integrity": "sha512-l+eW1hrjH9iJ7BR2BezFyYnofMaedAO5I4+nc+Q9RvB1WXMFNwxHgf3VkYz7/zW4iDdw7urIng5sZPvsmKxLww=="
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "cwms"
     ],
     "dependencies": {
-        "cwmsjs": "^1.15.0",
+        "cwmsjs": "^2.1.5-2024.11.14",
         "dayjs": "^1.11.11",
         "ol": "^10.0.0",
         "plotly.js-basic-dist": "^2.33.0",


### PR DESCRIPTION
- Upgrade cwmsjs package to v2.1.5-2024.11.14 (major version increment)
- Fix data hook cwmsjs function names as needed (mainly remove CwmsData)
- Remove old tsc error suppression (cwmsjs typing is fixed now)