### PR TITLE
Fix external libs and cda latest hook

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,10 +9,9 @@
             "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
-                "@usace-watermanagement/groundwork-water": "^2.4.0",
+                "@usace-watermanagement/groundwork-water": "^2.5.0",
                 "@usace/groundwork": "^3.1.0",
                 "clsx": "^2.1.0",
-                "cwmsjs": "^1.15.0",
                 "dayjs": "^1.11.11",
                 "internal-nav-helper": "^3.1.0",
                 "ol": "^9.2.4",
@@ -1161,9 +1160,9 @@
             "dev": true
         },
         "node_modules/@types/rbush": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-3.0.4.tgz",
-            "integrity": "sha512-knSt9cCW8jj1ZSFcFeBZaX++OucmfPxxHiRwTahZfJlnQsek7O0bazTJHWD2RVj9LEoejUYF2de3/stf+QXcXw=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+            "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ=="
         },
         "node_modules/@types/react": {
             "version": "18.3.3",
@@ -1197,11 +1196,11 @@
             "dev": true
         },
         "node_modules/@usace-watermanagement/groundwork-water": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@usace-watermanagement/groundwork-water/-/groundwork-water-2.4.0.tgz",
-            "integrity": "sha512-bWpReNCqUbgSbq34bdRQWpqew9P+nhEgMp21FjS0v6KADi8WkaAVdZsrFrAy+6uloZpuBnjUKy3q2dp41lFr1A==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@usace-watermanagement/groundwork-water/-/groundwork-water-2.5.0.tgz",
+            "integrity": "sha512-mW49xWFQlVK5jvm7IQpUKFKVkPL/3MvSoSa2yvh5l38iVWk8oNSsIA2EMXKQSURCXsEzO/B0XJQ2DLSFr8dg/g==",
             "dependencies": {
-                "cwmsjs": "^1.15.0",
+                "cwmsjs": "^2.1.5-2024.11.14",
                 "dayjs": "^1.11.11",
                 "ol": "^10.0.0",
                 "plotly.js-basic-dist": "^2.33.0",
@@ -1214,21 +1213,26 @@
                 "react-dom": "^18.2.0"
             }
         },
+        "node_modules/@usace-watermanagement/groundwork-water/node_modules/cwmsjs": {
+            "version": "2.1.5-2024.11.14",
+            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-2.1.5-2024.11.14.tgz",
+            "integrity": "sha512-l+eW1hrjH9iJ7BR2BezFyYnofMaedAO5I4+nc+Q9RvB1WXMFNwxHgf3VkYz7/zW4iDdw7urIng5sZPvsmKxLww=="
+        },
         "node_modules/@usace-watermanagement/groundwork-water/node_modules/earcut": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
             "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg=="
         },
         "node_modules/@usace-watermanagement/groundwork-water/node_modules/ol": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/ol/-/ol-10.1.0.tgz",
-            "integrity": "sha512-/efepydpzhFoeczA9KAN5t7G0WpFhP46ZXEfSl6JbZ7ipQZ2axpkYB2qt0qcOUlPFYMt7/XQFApH652KB08tTg==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ol/-/ol-10.3.1.tgz",
+            "integrity": "sha512-D1nRQVLOBCRempVqBFV8pSI5H13BtnhuLDjGl+3NKdMOFyjx/UqRX/tcMspEw3LhFOSPWn1Ev+1KIRV8AlHM7A==",
             "dependencies": {
-                "@types/rbush": "^3.0.3",
+                "@types/rbush": "4.0.0",
                 "color-rgba": "^3.0.0",
                 "color-space": "^2.0.1",
                 "earcut": "^3.0.0",
-                "geotiff": "^2.0.7",
+                "geotiff": "^2.1.3",
                 "pbf": "4.0.1",
                 "rbush": "^4.0.0"
             },
@@ -1904,11 +1908,6 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true
-        },
-        "node_modules/cwmsjs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-1.15.0.tgz",
-            "integrity": "sha512-HmIX9oNXEWwvT1FU5i0fe4rJthm6yOIuiaGozQt47ydB3hCpRLSbUd6eJytgIbX22A2gS5ErDPozSTbEgDeYuw=="
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,10 +11,9 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@usace-watermanagement/groundwork-water": "^2.4.0",
+        "@usace-watermanagement/groundwork-water": "^2.5.0",
         "@usace/groundwork": "^3.1.0",
         "clsx": "^2.1.0",
-        "cwmsjs": "^1.15.0",
         "dayjs": "^1.11.11",
         "internal-nav-helper": "^3.1.0",
         "ol": "^9.2.4",

--- a/docs/src/pages/docs/hooks/use-cda-catalog.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-catalog.jsx
@@ -28,7 +28,10 @@ const CatalogCard = () => {
         <li>TimeSeries ID: Latest Timestamp</li>
         {data.entries.map((entry) => (
           <li key={entry.name}>
-            {entry.name}: {entry.extents?.[0]?.latestTime.toISOString()}
+            {entry.name}:{" "}
+            {entry.extents?.[0]?.latestTime
+              ? entry.extents[0].latestTime.toISOString()
+              : "No data"}
           </li>
         ))}
       </ul>
@@ -88,7 +91,7 @@ const CatalogCard = () => {
       <CdaParamsTable
         requestObject="Catalog"
         requestType="GET"
-        cwmsJsType="GetCwmsDataCatalogWithDatasetRequest"
+        cwmsJsType="GetCatalogWithDatasetRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaCatalogParams} />

--- a/docs/src/pages/docs/hooks/use-cda-location.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-location.jsx
@@ -105,7 +105,7 @@ const LocationCard = () => {
       <CdaParamsTable
         requestObject="Location"
         requestType="GET"
-        cwmsJsType="GetCwmsDataLocationsWithLocationIdRequest"
+        cwmsJsType="GetLocationsWithLocationIdRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaParams} />

--- a/docs/src/pages/docs/hooks/use-cda-time-series-group.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-time-series-group.jsx
@@ -114,7 +114,7 @@ const TimeSeriesGroupList = () => {
       <CdaParamsTable
         requestObject="TimeSeries Group"
         requestType="GET"
-        cwmsJsType="GetCwmsDataTimeseriesGroupWithGroupIdRequest"
+        cwmsJsType="GetCwmsDataTimeSeriesGroupWithGroupIdRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaParams} />

--- a/docs/src/pages/docs/hooks/use-cda-time-series-group.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-time-series-group.jsx
@@ -114,7 +114,7 @@ const TimeSeriesGroupList = () => {
       <CdaParamsTable
         requestObject="TimeSeries Group"
         requestType="GET"
-        cwmsJsType="GetCwmsDataTimeSeriesGroupWithGroupIdRequest"
+        cwmsJsType="GetTimeSeriesGroupWithGroupIdRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaParams} />

--- a/docs/src/pages/docs/hooks/use-cda-time-series.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-time-series.jsx
@@ -110,7 +110,7 @@ const OutflowCard = () => {
       <CdaParamsTable
         requestObject="TimeSeries"
         requestType="GET"
-        cwmsJsType="GetCwmsDataTimeSeriesRequest"
+        cwmsJsType="GetTimeSeriesRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaTSHookParams} />

--- a/docs/src/pages/docs/hooks/use-cda-time-series.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-time-series.jsx
@@ -18,7 +18,7 @@ const OutflowCard = () => {
   });
 
   if (isPending) return <span>Loading timeseries data...</span>;
-  if (isError) return <span>Timeseries error!</span>;
+  if (isError) return <span>TimeSeries error!</span>;
 
   return (
     <Card className="gw-w-96">
@@ -74,7 +74,7 @@ const OutflowCard = () => {
   });
 
   if (isPending) return <span>Loading timeseries data...</span>;
-  if (isError) return <span>Timeseries error!</span>;
+  if (isError) return <span>TimeSeries error!</span>;
 
   return (
     <Card className="w-96">
@@ -110,7 +110,7 @@ const OutflowCard = () => {
       <CdaParamsTable
         requestObject="TimeSeries"
         requestType="GET"
-        cwmsJsType="GetCwmsDataTimeseriesRequest"
+        cwmsJsType="GetCwmsDataTimeSeriesRequest"
       />
       <div className="font-bold text-lg pt-6">cdaParams</div>
       <ParamsTable paramsList={cdaTSHookParams} />

--- a/docs/src/pages/docs/plots/index.jsx
+++ b/docs/src/pages/docs/plots/index.jsx
@@ -21,7 +21,7 @@ function Plots() {
       prevText="Return to React Query Page"
       nextText="Go to Tables Page"
     >
-      <UsaceBox title="Generic Timeseries Plot">
+      <UsaceBox title="Generic TimeSeries Plot">
         <TSPlot
           cdaParams={{
             name: "KEYS.Elev.Inst.1Hour.0.Ccp-Rev",

--- a/docs/src/pages/docs/tables/index.jsx
+++ b/docs/src/pages/docs/tables/index.jsx
@@ -24,7 +24,7 @@ function Tables() {
     >
       <div className="mt-6">
         <TSTable
-          title="Simple Timeseries Table"
+          title="Simple TimeSeries Table"
           cdaParams={{
             office: "SWT",
             name: tsid,
@@ -52,7 +52,7 @@ default export function Example() {
 
     return (
     <TSTable
-        title="Simple Timeseries Table"
+        title="Simple TimeSeries Table"
         cdaParams={{
         office: "SWT",
         name: tsid,

--- a/lib/components/data/hooks/useCdaLatestValue.ts
+++ b/lib/components/data/hooks/useCdaLatestValue.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import useCdaCatalog from "./useCdaCatalog";
 import useCdaTimeSeries from "./useCdaTimeSeries";
 import { getLatestEntry } from "../helpers/cda";
-import { TimeseriesCatalogEntry } from "cwmsjs";
+import { TimeSeriesCatalogEntry } from "cwmsjs";
 
 interface useCdaLatestValueParams {
   tsId: string;
@@ -45,7 +45,7 @@ const useCdaLatestValue = ({
     if (!catalog.data || !catalog.data.entries) {
       return;
     }
-    const firstEntry: TimeseriesCatalogEntry = catalog.data.entries?.[0];
+    const firstEntry: TimeSeriesCatalogEntry = catalog.data.entries?.[0];
     if (!firstEntry.extents?.[0].latestTime) {
       return;
     }

--- a/lib/components/data/plots/CWMSPlot.jsx
+++ b/lib/components/data/plots/CWMSPlot.jsx
@@ -40,7 +40,7 @@ export default function CWMSPlot({
       setPlotTitle((Array.isArray(tsids) ? tsids[0] : tsids).split(".")[0]);
     }
     if (!tsids.length)
-      throw Error("You must specify one or more Timeseries IDs to plot.");
+      throw Error("You must specify one or more TimeSeries IDs to plot.");
     if (!office) throw Error("You must specify a 3 letter ID for the office");
     if (typeof tsids == "string") {
       tsids = [tsids];
@@ -51,7 +51,7 @@ export default function CWMSPlot({
   const fetchData = async () => {
     let promises = plotTSIDs.map(async (name) => {
       try {
-        return await ts_api.getCwmsDataTimeseries({
+        return await ts_api.getCwmsDataTimeSeries({
           name,
           end,
           unit,

--- a/lib/components/data/plots/CWMSPlot.jsx
+++ b/lib/components/data/plots/CWMSPlot.jsx
@@ -51,7 +51,7 @@ export default function CWMSPlot({
   const fetchData = async () => {
     let promises = plotTSIDs.map(async (name) => {
       try {
-        return await ts_api.getCwmsDataTimeSeries({
+        return await ts_api.getTimeSeries({
           name,
           end,
           unit,

--- a/lib/components/data/plots/TSPlot.jsx
+++ b/lib/components/data/plots/TSPlot.jsx
@@ -13,7 +13,7 @@ import Plotly from "plotly.js-basic-dist";
  * @returns {JSX.Element} The rendered component.
  */
 const TSPlot = ({
-  title = "Timeseries Plot",
+  title = "TimeSeries Plot",
   cdaParams = null,
   cdaUrl = null,
   queryOptions = null,

--- a/lib/components/data/tables/TSTable.jsx
+++ b/lib/components/data/tables/TSTable.jsx
@@ -15,7 +15,7 @@ const TS_API = new TimeSeriesApi(V2_API);
 
 const fetchData = async ({ queryKey }) => {
   const [, cdaParams] = queryKey;
-  const response = await TS_API.getCwmsDataTimeseriesRaw(cdaParams);
+  const response = await TS_API.getCwmsDataTimeSeriesRaw(cdaParams);
   const data = await response.raw.json();
   data.url = response.raw.url;
   return data;

--- a/lib/components/data/tables/TSTable.jsx
+++ b/lib/components/data/tables/TSTable.jsx
@@ -15,7 +15,7 @@ const TS_API = new TimeSeriesApi(V2_API);
 
 const fetchData = async ({ queryKey }) => {
   const [, cdaParams] = queryKey;
-  const response = await TS_API.getCwmsDataTimeSeriesRaw(cdaParams);
+  const response = await TS_API.getTimeSeriesRaw(cdaParams);
   const data = await response.raw.json();
   data.url = response.raw.url;
   return data;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
-                "cwmsjs": "^2.1.5-2024.11.14",
+                "cwmsjs": "^2.3.0-2024.12.10",
                 "dayjs": "^1.11.11",
                 "ol": "^10.0.0",
                 "plotly.js-basic-dist": "^2.33.0",
@@ -2426,9 +2426,9 @@
             "dev": true
         },
         "node_modules/cwmsjs": {
-            "version": "2.1.5-2024.11.14",
-            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-2.1.5-2024.11.14.tgz",
-            "integrity": "sha512-l+eW1hrjH9iJ7BR2BezFyYnofMaedAO5I4+nc+Q9RvB1WXMFNwxHgf3VkYz7/zW4iDdw7urIng5sZPvsmKxLww=="
+            "version": "2.3.0-2024.12.10",
+            "resolved": "https://registry.npmjs.org/cwmsjs/-/cwmsjs-2.3.0-2024.12.10.tgz",
+            "integrity": "sha512-5uPKl24caND+JR0C/3LLQ9cXmHy/lW4//PB+bykQ2kCKGvKOu8sdmeOaP3NbMGyHdsc6kGWJplZKmcsJEp0tBA=="
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "cwms"
     ],
     "dependencies": {
-        "cwmsjs": "^2.1.5-2024.11.14",
+        "cwmsjs": "^2.3.0-2024.12.10",
         "dayjs": "^1.11.11",
         "ol": "^10.0.0",
         "plotly.js-basic-dist": "^2.33.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,48 +5,54 @@ import pkg from "./package.json";
 
 // Based off of Groundwork proper's lib vs doc config
 export default defineConfig(({ mode }) => {
-    if (mode === "lib") {
-        console.log("Building library");
-        return {
-            plugins: [react(), tailwindcss()],
-            publicDir: false,
-            build: {
-                minify: false,
-                lib: {
-                    name: "GroundworkWater",
-                    fileName: (format) => `groundwork-water.${format}.js`,
-                    entry: "lib/index.jsx",
-                    formats: ['es', 'umd']
-                },
-                rollupOptions: {
-                    external: ["react", "react-dom", "@tanstack/react-query", "ol", "plotly.js-basic-dist"],
-                    output: {
-                        globals: {
-                            react: "React",
-                            "react-dom": "ReactDOM",
-                            "@tanstack/react-query": "ReactQuery",
-                            ol: "ol",
-                            "plotly.js-basic-dist": "Plotly",
-                        },
-                    },
-                },
+  if (mode === "lib") {
+    console.log("Building library");
+    return {
+      plugins: [react(), tailwindcss()],
+      publicDir: false,
+      build: {
+        minify: false,
+        lib: {
+          name: "GroundworkWater",
+          fileName: (format) => `groundwork-water.${format}.js`,
+          entry: "lib/index.jsx",
+          formats: ["es", "umd"],
+        },
+        rollupOptions: {
+          external: [
+            "react",
+            "react-dom",
+            "@tanstack/react-query",
+            "ol",
+            "plotly.js-basic-dist",
+          ],
+          output: {
+            globals: {
+              react: "React",
+              "react-dom": "ReactDOM",
+              "@tanstack/react-query": "ReactQuery",
+              ol: "ol",
+              "plotly.js-basic-dist": "Plotly",
             },
-        }
-    } else {
-        console.log("Building Docs App: ", mode);
-        const base =
-            mode === "production"
-                ? "https://USACE-WaterManagement.github.io/groundwork-water/"
-                : "http://localhost:5173/";
-        return {
-            plugins: [react(), tailwindcss()],
-            base: base,
-            build: {
-                outDir: "docs",
-            },
-            define: {
-                "import.meta.env.PKG_VERSION": JSON.stringify(pkg.version),
-            },
-        };
-    }
-})
+          },
+        },
+      },
+    };
+  } else {
+    console.log("Building Docs App: ", mode);
+    const base =
+      mode === "production"
+        ? "https://USACE-WaterManagement.github.io/groundwork-water/"
+        : "http://localhost:5173/";
+    return {
+      plugins: [react(), tailwindcss()],
+      base: base,
+      build: {
+        outDir: "docs",
+      },
+      define: {
+        "import.meta.env.PKG_VERSION": JSON.stringify(pkg.version),
+      },
+    };
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,8 @@ export default defineConfig(({ mode }) => {
             "@tanstack/react-query",
             "ol",
             "plotly.js-basic-dist",
+            "cwmsjs",
+            "@usace/groundwork",
           ],
           output: {
             globals: {
@@ -33,6 +35,7 @@ export default defineConfig(({ mode }) => {
               "@tanstack/react-query": "ReactQuery",
               ol: "ol",
               "plotly.js-basic-dist": "Plotly",
+              cwmsjs: "cwmsjs",
             },
           },
         },


### PR DESCRIPTION
- Bump version of Groundwork Water to fix issues with cwmsjs version missmatch 
- Update to latest CWMSjs that converts `Timeseries` to `TimeSeries`. 
- Minor fix on use-cda-catalog