### PR TITLE
Using lib version for header instead of doc site version

### DIFF
--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import pkg from "./package.json";
+import pkg from "../package.json";
 import tailwindcss from "tailwindcss";
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
A simple fix, but it begs the question. Does the version in 
- https://github.com/USACE-WaterManagement/groundwork-water/blob/e8b4d30fe81b3550ddc669862b4893422c9a6fb1/docs/package.json#L5
serve a purpose?

Suggest we just set this to 0.0.0 and ignore it if we plan to not have sep versions for the docs themselves. 

I do wonder if there's a way to enable doc site versioning somehow within GitHub pages. 

Solves:
- #65

