### PR TITLE
AuthProvider component - Authentication Handling

### DIFF
--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -14,6 +14,7 @@ import AuthenticationDocs from "../pages/docs/auth";
 import AuthMethodDocs from "../pages/docs/auth/auth-method";
 import AuthProviderDocs from "../pages/docs/auth/auth-provider";
 import CwmsLoginDocs from "../pages/docs/auth/cwms-login";
+import KeycloakDocs from "../pages/docs/auth/keycloak";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -36,6 +37,7 @@ export default createRouteBundle(
     "/docs/auth/auth-method": AuthMethodDocs,
     "/docs/auth/auth-provider": AuthProviderDocs,
     "/docs/auth/cwms-login": CwmsLoginDocs,
+    "/docs/auth/keycloak": KeycloakDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -11,6 +11,7 @@ import ReactQuery from "../pages/docs/react-query";
 import AddComponents from "../pages/docs/add-components";
 import QuickStart from "../pages/docs/quick-start";
 import AuthenticationDocs from "../pages/docs/auth";
+import AuthMethodDocs from "../pages/docs/auth/auth-method";
 import AuthProviderDocs from "../pages/docs/auth/auth-provider";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
@@ -31,6 +32,7 @@ export default createRouteBundle(
     "/docs/cards/cda-latest-value-card": CdaLatestValueCardDocs,
     "/docs/help": HelpPage,
     "/docs/auth": AuthenticationDocs,
+    "/docs/auth/auth-method": AuthMethodDocs,
     "/docs/auth/auth-provider": AuthProviderDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -13,6 +13,7 @@ import QuickStart from "../pages/docs/quick-start";
 import AuthenticationDocs from "../pages/docs/auth";
 import AuthMethodDocs from "../pages/docs/auth/auth-method";
 import AuthProviderDocs from "../pages/docs/auth/auth-provider";
+import CwmsLoginDocs from "../pages/docs/auth/cwms-login";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -34,6 +35,7 @@ export default createRouteBundle(
     "/docs/auth": AuthenticationDocs,
     "/docs/auth/auth-method": AuthMethodDocs,
     "/docs/auth/auth-provider": AuthProviderDocs,
+    "/docs/auth/cwms-login": CwmsLoginDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -10,6 +10,7 @@ import Docs from "../pages/docs/";
 import ReactQuery from "../pages/docs/react-query";
 import AddComponents from "../pages/docs/add-components";
 import QuickStart from "../pages/docs/quick-start";
+import AuthenticationDocs from "../pages/docs/auth";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -28,6 +29,7 @@ export default createRouteBundle(
     "/docs": Docs,
     "/docs/cards/cda-latest-value-card": CdaLatestValueCardDocs,
     "/docs/help": HelpPage,
+    "/docs/auth": AuthenticationDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -15,6 +15,7 @@ import AuthMethodDocs from "../pages/docs/auth/auth-method";
 import AuthProviderDocs from "../pages/docs/auth/auth-provider";
 import CwmsLoginDocs from "../pages/docs/auth/cwms-login";
 import KeycloakDocs from "../pages/docs/auth/keycloak";
+import UseAuthDocs from "../pages/docs/auth/use-auth";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -38,6 +39,7 @@ export default createRouteBundle(
     "/docs/auth/auth-provider": AuthProviderDocs,
     "/docs/auth/cwms-login": CwmsLoginDocs,
     "/docs/auth/keycloak": KeycloakDocs,
+    "/docs/auth/use-auth": UseAuthDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -11,6 +11,7 @@ import ReactQuery from "../pages/docs/react-query";
 import AddComponents from "../pages/docs/add-components";
 import QuickStart from "../pages/docs/quick-start";
 import AuthenticationDocs from "../pages/docs/auth";
+import AuthProviderDocs from "../pages/docs/auth/auth-provider";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -30,6 +31,7 @@ export default createRouteBundle(
     "/docs/cards/cda-latest-value-card": CdaLatestValueCardDocs,
     "/docs/help": HelpPage,
     "/docs/auth": AuthenticationDocs,
+    "/docs/auth/auth-provider": AuthProviderDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/components/QueryClientWarning.jsx
+++ b/docs/src/components/QueryClientWarning.jsx
@@ -1,19 +1,22 @@
-import { Card, Text } from "@usace/groundwork";
-import { IoWarning } from "react-icons/io5";
+import Alert from "../pages/components/alert";
 
 const QueryClientWarning = () => {
   return (
-    <Card className="my-2 flex">
-      <IoWarning size="1.5rem" className="flex-none mr-2 text-gray-700" />
-      <Text>
-        Use of the groundwork data hooks requires that your application be
-        wrapped in a QueryClientProvider. Refer to the{" "}
-        <a href="/docs/react-query" className="underline">
-          Getting Started - React-Query
-        </a>{" "}
-        page.
-      </Text>
-    </Card>
+    <Alert
+      className="my-2"
+      status="warning"
+      title="NOTE"
+      message={
+        <span>
+          Use of this component requires that your application be wrapped in a
+          QueryClientProvider. Refer to the{" "}
+          <a href="/docs/react-query" className="underline">
+            Getting Started - React-Query
+          </a>{" "}
+          page.
+        </span>
+      }
+    />
   );
 };
 

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -25,6 +25,13 @@ export default [
     id: "auth",
     text: "Authentication",
     href: "/docs/auth",
+    children: [
+      {
+        id: "auth-provider",
+        text: "AuthProvider",
+        href: "/docs/auth/auth-provider",
+      },
+    ],
   },
   {
     id: "hooks",

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -22,6 +22,11 @@ export default [
     ],
   },
   {
+    id: "auth",
+    text: "Authentication",
+    href: "/docs/auth",
+  },
+  {
     id: "hooks",
     text: "Data Hooks",
     href: "/docs/hooks",

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -41,6 +41,11 @@ export default [
         text: "CWMSLogin Method",
         href: "/docs/auth/cwms-login",
       },
+      {
+        id: "keycloak",
+        text: "Keycloak Method",
+        href: "/docs/auth/keycloak",
+      },
     ],
   },
   {

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -36,6 +36,11 @@ export default [
         text: "AuthProvider",
         href: "/docs/auth/auth-provider",
       },
+      {
+        id: "cwms-login",
+        text: "CWMSLogin Method",
+        href: "/docs/auth/cwms-login",
+      },
     ],
   },
   {

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -46,6 +46,11 @@ export default [
         text: "Keycloak Method",
         href: "/docs/auth/keycloak",
       },
+      {
+        id: "use-auth",
+        text: "useAuth Hook",
+        href: "/docs/auth/use-auth",
+      },
     ],
   },
   {

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -27,6 +27,11 @@ export default [
     href: "/docs/auth",
     children: [
       {
+        id: "auth-method",
+        text: "AuthMethod",
+        href: "/docs/auth/auth-method",
+      },
+      {
         id: "auth-provider",
         text: "AuthProvider",
         href: "/docs/auth/auth-provider",

--- a/docs/src/pages/docs/auth/auth-method.jsx
+++ b/docs/src/pages/docs/auth/auth-method.jsx
@@ -1,0 +1,96 @@
+import { Code, Text } from "@usace/groundwork";
+import PropsTable from "../../components/props-table";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+
+const componentProps = [
+  {
+    name: "login",
+    type: "() => Promise<void>",
+    default: "undefined",
+    desc: "A function that handles user login with the authentication platform.",
+  },
+  {
+    name: "logout",
+    type: "() => Promise<void>",
+    default: "undefined",
+    desc: "A function that logs the user out of authentication platform.",
+  },
+  {
+    name: "isAuth",
+    type: "() => Promise<boolean>",
+    default: "undefined",
+    desc: "A function that returns the authentication status of the user.",
+  },
+  {
+    name: "refresh",
+    type: "() => Promise<void>",
+    default: "undefined",
+    desc: "Optional - A function that refreshes the user's access token.",
+  },
+  {
+    name: "refreshInterval",
+    type: "number",
+    default: "undefined",
+    desc: "Optional - Time between refresh token requests, in seconds.",
+  },
+  {
+    name: "token",
+    type: "string",
+    default: "undefined",
+    desc: "Optional - A string containing the user's access token.",
+  },
+];
+
+const authProvider = (
+  <a href="/docs/auth/auth-provider" className="hover:underline">
+    <Code>&lt;AuthProvider&gt;</Code>
+  </a>
+);
+const authMethod = <Code>AuthMethod</Code>;
+
+function AuthMethodDocs() {
+  return (
+    <DocsPage middleText="{componentCode}">
+      <div>
+        <Text>
+          An {authMethod} is an interface for linking an authentication platform
+          with an {authProvider}.
+        </Text>
+        <Text className="mt-4">
+          Constructor functions are available in Groundwork-Water to create an{" "}
+          {authMethod} for authentication platforms that are commonly used
+          within the water management community. These functions require the
+          user to provide only a configuration (url, user details, etc.) and
+          will handle the nuts and bolts internally. The following constructor
+          functions are currently available:
+        </Text>
+        <ul className="list-disc mt-2 ml-8 text-gray-500">
+          <li>
+            <a href="/docs/auth/keycloak" className="hover:underline">
+              createKeycloakAuthMethod()
+            </a>
+          </li>
+          <li>
+            <a href="/docs/auth/cwms-login" className="hover:underline">
+              createCwmsLoginAuthMethod()
+            </a>
+          </li>
+        </ul>
+        <Text className="mt-4">
+          While use of the provided functions is recommended where applicable,
+          custom {authMethod} objects can be created for advanced use cases. The
+          interface shape is provided here for reference.
+        </Text>
+      </div>
+      <Divider text="API Reference" className="mt-6" />
+      <div className="font-bold text-lg pt-6">
+        interface <Code className="p-2">{`AuthMethod`}</Code>
+      </div>
+      <PropsTable propsList={componentProps} />
+    </DocsPage>
+  );
+}
+
+export { AuthMethodDocs };
+export default AuthMethodDocs;

--- a/docs/src/pages/docs/auth/auth-provider.jsx
+++ b/docs/src/pages/docs/auth/auth-provider.jsx
@@ -1,0 +1,74 @@
+import { Code, Text } from "@usace/groundwork";
+import PropsTable from "../../components/props-table";
+import { Code as CodeBlock } from "../../components/code";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+import QueryClientWarning from "../../../components/QueryClientWarning";
+
+const componentProps = [
+  {
+    name: "method",
+    type: "AuthMethod",
+    default: "undefined",
+    desc: "An authentication method with configuration options appropriate for your environment.",
+  },
+];
+
+const authProvider = <Code>AuthProvider</Code>;
+const authMethod = (
+  <a href="/docs/auth/auth-method" className="hover:underline">
+    <Code>AuthMethod</Code>
+  </a>
+);
+const useAuth = (
+  <a href="/docs/auth/use-auth" className="hover:underline">
+    <Code>useAuth()</Code>
+  </a>
+);
+
+function AuthProviderDocs() {
+  return (
+    <DocsPage middleText="{componentCode}">
+      <div>
+        <Text>
+          The {authProvider} is a wrapper that provides your authentication
+          context to the rest of your application.
+        </Text>
+        <Text className="mt-4">
+          Configuration of your authentication environment is handled by an{" "}
+          {authMethod} that is passed into the {authProvider}.
+        </Text>
+        <Text className="mt-4">
+          Within the {authProvider}, access to your authentication context is
+          provided through the {useAuth} hook.
+        </Text>
+        <QueryClientWarning />
+      </div>
+      <Divider text="Example Usage" className="mt-6 mb-4" />
+      <Text>Import the AuthProvider at the top of your application with:</Text>
+      <CodeBlock language="jsx">
+        {`import { AuthProvider } from "@usace-watermanagement/groundwork-water";`}
+      </CodeBlock>
+      <Text className="mb-4">Create an appropriate {authMethod}.</Text>
+      <Text>Wrap your application with an {authProvider}:</Text>
+      <CodeBlock language="jsx">
+        {`<React.StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider method={authMethod}>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  </QueryClientProvider>
+</React.StrictMode>
+`}
+      </CodeBlock>
+      <Divider text="API Reference" />
+      <div className="font-bold text-lg pt-6">
+        Component API - <Code className="p-2">{`<CdaUrlProvider />`}</Code>
+      </div>
+      <PropsTable propsList={componentProps} />
+    </DocsPage>
+  );
+}
+
+export { AuthProviderDocs };
+export default AuthProviderDocs;

--- a/docs/src/pages/docs/auth/cwms-login.jsx
+++ b/docs/src/pages/docs/auth/cwms-login.jsx
@@ -1,0 +1,75 @@
+import { Code, Text } from "@usace/groundwork";
+import { Code as CodeBlock } from "../../components/code";
+import PropsTable from "../../components/props-table";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+
+const componentProps = [
+  {
+    name: "authUrl",
+    type: "string",
+    default: "undefined",
+    desc: "The URL for the CWMSLogin provider, e.g. https://host:8243/CWMSLogin",
+  },
+  {
+    name: "authCheckUrl",
+    type: "string",
+    default: "undefined",
+    desc: "The URL for a GET endpoint that can be used to check authentication status, e.g. https://host:8243/cwms-data/auth/keys",
+  },
+];
+
+const cwmsLogin = <Code>createCwmsLoginAuthMethod()</Code>;
+const authMethod = (
+  <a href="/docs/auth/auth-method" className="hover:underline">
+    <Code>AuthMethod</Code>
+  </a>
+);
+
+function CwmsLoginDocs() {
+  return (
+    <DocsPage middleText="{componentCode}">
+      <div>
+        <Text>
+          The {cwmsLogin} function returns an {authMethod} configured to
+          authenticate using a CWMSLogin provider.
+        </Text>
+        <Text className="mt-4">
+          The function must be passed a configuration object with two values:
+          the host URL for the CWMSLogin instance and the URL for an API
+          endpoint that can be used to check authentication status.
+        </Text>
+        <Text className="mt-4">
+          This authentication method expects that the access token will be
+          handled using cookies. Therefore, the token string itself is managed
+          by the browser and will not be directly available to the application.
+        </Text>
+        <Text className="mt-4">
+          When making requests using this authentication method, be sure to set{" "}
+          <Code>credentials: `include`</Code> in the request headers. This will
+          ensure that the authentication cookie is included with the request.
+        </Text>
+      </div>
+      <Divider text="Example Usage" className="mt-6 mb-4" />
+      <CodeBlock language="jsx">
+        {`import { createCwmsLoginAuthMethod } from "@usace-watermanagement/groundwork-water";
+
+// Set authHost and cdaUrl from environment variables
+
+const authMethod = createCwmsLoginAuthMethod({
+  authUrl: authHost,
+  authCheckUrl: \`\${cdaUrl}/auth/keys
+});`}
+      </CodeBlock>
+      <Divider text="API Reference" className="mt-6" />
+      <div className="font-bold text-lg pt-6">
+        config -{" "}
+        <Code className="p-2">{`createCwmsLoginAuthMethod(config)`}</Code>
+      </div>
+      <PropsTable propsList={componentProps} />
+    </DocsPage>
+  );
+}
+
+export { CwmsLoginDocs };
+export default CwmsLoginDocs;

--- a/docs/src/pages/docs/auth/index.jsx
+++ b/docs/src/pages/docs/auth/index.jsx
@@ -20,6 +20,45 @@ const useAuth = (
   </a>
 );
 
+export const AuthHookExample = () => (
+  <CodeBlock language="jsx">
+    {`import { LoginButton, ProfileDropdown } from "@usace/groundwork";
+import { useAuth } from "@usace-watermanagement/groundwork-water";
+
+function Component() {
+  const auth = useAuth();
+  
+  return (
+    <div className="flex justify-between items-center bg-usace-black text-white rounded-2 p-2">
+      {auth.isAuth ? (
+        <ProfileDropdown
+          showLogout
+          onLogout={auth.logout}
+          links={[
+            {
+              id: "profile",
+              text: "View Profile",
+              link: "#",
+            },
+          ]}
+        />
+      ) : (
+        <LoginButton
+          onClick={auth.login}
+        />
+      )}
+      {auth.isAuth && (
+        <span className="italic font-light text-sm">{"Logged in!"}</span>
+      )}
+    </div>
+  )
+}
+
+export default Component;
+`}
+  </CodeBlock>
+);
+
 function AuthenticationDocs() {
   return (
     <DocsPage middleText="Authentication">
@@ -121,42 +160,7 @@ const authMethod = createCwmsLoginAuthMethod({
         </a>{" "}
         by incorporating our built-in authentication handling:
       </Text>
-      <CodeBlock language="jsx">
-        {`import { LoginButton, ProfileDropdown } from "@usace/groundwork";
-import { useAuth } from "@usace-watermanagement/groundwork-water";
-
-function Component() {
-  const auth = useAuth();
-  
-  return (
-    <div className="flex justify-between items-center bg-usace-black text-white rounded-2 p-2">
-      {auth.isAuth ? (
-        <ProfileDropdown
-          showLogout
-          onLogout={auth.logout}
-          links={[
-            {
-              id: "profile",
-              text: "View Profile",
-              link: "#",
-            },
-          ]}
-        />
-      ) : (
-        <LoginButton
-          onClick={auth.login}
-        />
-      )}
-      {auth.isAuth && (
-        <span className="italic font-light text-sm">{"Logged in!"}</span>
-      )}
-    </div>
-  )
-}
-
-export default Component;
-`}
-      </CodeBlock>
+      <useAuthExample />
     </DocsPage>
   );
 }

--- a/docs/src/pages/docs/auth/index.jsx
+++ b/docs/src/pages/docs/auth/index.jsx
@@ -2,6 +2,7 @@ import { Code, H4, Text } from "@usace/groundwork";
 import { Code as CodeBlock } from "../../components/code";
 import DocsPage from "../_docs-wrapper";
 import Divider from "../../components/divider";
+import QueryClientWarning from "../../../components/QueryClientWarning";
 
 const authMethod = (
   <a href="/docs/auth/auth-method" className="hover:underline">
@@ -55,8 +56,9 @@ function AuthenticationDocs() {
             functionality where needed
           </li>
         </ul>
+        <QueryClientWarning />
       </div>
-      <Divider text="Setup" className="mt-8 mb-4" />
+      <Divider text="Setup" className="mt-6 mb-4" />
       <Text>
         These examples provide a brief overview of authentication setup. Please
         refer to the individual component documentation pages for more detailed

--- a/docs/src/pages/docs/auth/index.jsx
+++ b/docs/src/pages/docs/auth/index.jsx
@@ -1,0 +1,163 @@
+import { Code, H4, Text } from "@usace/groundwork";
+import { Code as CodeBlock } from "../../components/code";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+
+const authMethod = (
+  <a href="/docs/auth/auth-method" className="hover:underline">
+    <Code>AuthMethod</Code>
+  </a>
+);
+const authProvider = (
+  <a href="/docs/auth/auth-provider" className="hover:underline">
+    <Code>&lt;AuthProvider&gt;</Code>;
+  </a>
+);
+const useAuth = (
+  <a href="/docs/auth/use-auth" className="hover:underline">
+    <Code>useAuth()</Code>
+  </a>
+);
+
+function AuthenticationDocs() {
+  return (
+    <DocsPage middleText="Authentication">
+      <div>
+        <Text>
+          Authentication management in Groundwork-Water is designed to support
+          common authentication platforms used by the water management community
+          such as Keycloak and CWMSLogin. Authentication is handled using three
+          main components:
+        </Text>
+        <ul className="list-disc ml-12 text-gray-500">
+          <li>
+            an {authMethod}, generally created using one of the provided
+            constructors:
+            <ul className="list-disc ml-8">
+              <li>
+                <a href="/docs/auth/keycloak" className="hover:underline">
+                  createKeycloakAuthMethod()
+                </a>
+              </li>
+              <li>
+                <a href="/docs/auth/cwms-login" className="hover:underline">
+                  createCwmsLoginAuthMethod()
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            an {authProvider} that wraps your application (or at least the part
+            requiring authentication)
+          </li>
+          <li>
+            a {useAuth} hook that provides access to authentication
+            functionality where needed
+          </li>
+        </ul>
+      </div>
+      <Divider text="Setup" className="mt-8 mb-4" />
+      <Text>
+        These examples provide a brief overview of authentication setup. Please
+        refer to the individual component documentation pages for more detailed
+        information.
+      </Text>
+      <H4 className="mt-4 mb-2">AuthMethod</H4>
+      <Text>
+        An {authMethod} object must be created to configure your authentication
+        within the {authProvider}. Typically, this can be done at the top level
+        of your application, e.g. App.jsx/tsx, using the provided constructor
+        functions.
+      </Text>
+      <CodeBlock language="jsx">
+        {`import { createCwmsLoginAuthMethod } from "@usace-watermanagement/groundwork-water";
+
+const authMethod = createCwmsLoginAuthMethod({
+  authUrl: "localhost:7000/CWMSLogin",
+  authCheckUrl: "localhost:7000/cwms-data/auth/keys",
+});
+`}
+      </CodeBlock>
+      <H4 className="mb-2">AuthProvider</H4>
+      <Text>
+        Your application (or the parts of your application requiring
+        authentication) must be wrapped in an {authProvider} component. The
+        previously-created {authMethod} will be passed to the {authProvider} to
+        apply the configuration within your application.
+      </Text>
+      <CodeBlock language="jsx">
+        {`import {
+  AuthProvider,
+  createCwmsLoginAuthMethod,
+} from "@usace-watermanagement/groundwork-water";
+
+// queryClient setup, authMethod setup, etc...
+        
+<React.StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider method={authMethod}>
+      <RouterProvider router={router} />
+    </AuthProvider>
+  </QueryClientProvider>
+</React.StrictMode>
+`}
+      </CodeBlock>
+      <H4 className="mb-2">useAuth()</H4>
+      <Text>
+        The {useAuth} hook provides access to your authentication context within
+        your application. This includes features such as login/logout methods,
+        an authentication status boolean, and, when applicable, a JWT token
+        string.
+      </Text>
+      <Text className="mt-2">
+        The following example expands upon the{" "}
+        <a
+          href="https://usace.github.io/groundwork/#/docs/buttons/login-button"
+          className="underline"
+        >
+          Groundwork LoginButton example
+        </a>{" "}
+        by incorporating our built-in authentication handling:
+      </Text>
+      <CodeBlock language="jsx">
+        {`import { LoginButton, ProfileDropdown } from "@usace/groundwork";
+import { useAuth } from "@usace-watermanagement/groundwork-water";
+
+function Component() {
+  const auth = useAuth();
+  
+  return (
+    <div className="flex justify-between items-center bg-usace-black text-white rounded-2 p-2">
+      {auth.isAuth ? (
+        <ProfileDropdown
+          showLogout
+          onLogout={auth.logout}
+          links={[
+            {
+              id: "profile",
+              text: "View Profile",
+              link: "#",
+            },
+          ]}
+        />
+      ) : (
+        <LoginButton
+          onClick={auth.login}
+        />
+      )}
+      {auth.isAuth && (
+        <span className="italic font-light text-sm">{"Logged in!"}</span>
+      )}
+    </div>
+  )
+}
+
+export default Component;
+`}
+      </CodeBlock>
+    </DocsPage>
+  );
+}
+
+export { AuthenticationDocs };
+export default AuthenticationDocs;

--- a/docs/src/pages/docs/auth/keycloak.jsx
+++ b/docs/src/pages/docs/auth/keycloak.jsx
@@ -1,0 +1,97 @@
+import { Code, Text } from "@usace/groundwork";
+import { Code as CodeBlock } from "../../components/code";
+import PropsTable from "../../components/props-table";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+
+const componentProps = [
+  {
+    name: "host",
+    type: "string",
+    default: "undefined",
+    desc: "The URL for the Keycloak instance",
+  },
+  {
+    name: "realm",
+    type: "string",
+    default: "undefined",
+    desc: "The Keycloak realm to use for authentication.",
+  },
+  {
+    name: "client",
+    type: "string",
+    default: "undefined",
+    desc: "The Keycloak client to use for authentication.",
+  },
+  {
+    name: "flow",
+    type: "string",
+    default: "undefined",
+    desc: "The authentication flow to use.  Currently only 'direct-grant' is supported.",
+  },
+  {
+    name: "refreshInterval",
+    type: "number",
+    default: "undefined",
+    desc: "Optional - The time between refresh token requests, in seconds",
+  },
+];
+
+const keycloak = <Code>createKeycloakAuthMethod()</Code>;
+const authMethod = (
+  <a href="/docs/auth/auth-method" className="hover:underline">
+    <Code>AuthMethod</Code>
+  </a>
+);
+
+function KeycloakDocs() {
+  return (
+    <DocsPage middleText="{componentCode}">
+      <div>
+        <Text>
+          The {keycloak} function returns an {authMethod} configured to
+          authenticate using a Keycloak instance.
+        </Text>
+        <Text className="mt-4">
+          The function must be passed a configuration object identifying the
+          host URL, realm, client, authentication flow, and optionally a custom
+          refresh interval for refresh token requests.
+        </Text>
+        <Text className="mt-4">
+          This authentication method uses refresh tokens and will automatically
+          manage requests and updates for the current access token. The interval
+          between refresh requests can be controlled by the refreshInterval
+          option.
+        </Text>
+        <Text className="mt-4">
+          When making requests using this authentication method, the access
+          token string will typically be included directly in the request
+          headers. For example, requests to CDA will require the following
+          header to be set: <Code>Authorization: `Bearer *token*`</Code>
+        </Text>
+      </div>
+      <Divider text="Example Usage" className="mt-6 mb-4" />
+      <CodeBlock language="jsx">
+        {`import { createKeycloakAuthMethod } from "@usace-watermanagement/groundwork-water";
+      
+// Set authHost from environment variables
+
+const authMethod = createKeycloakAuthMethod({
+  host: authHost,
+  realm: "cwms",
+  client: "cwms",
+  flow: "direct-grant",
+});`}
+      </CodeBlock>
+      <Divider text="API Reference" className="mt-6" />
+      <div className="font-bold text-lg pt-6">
+        config -{" "}
+        <Code className="p-2">{`createCwmsLoginAuthMethod(config)`}</Code>
+      </div>
+      <PropsTable propsList={componentProps} />
+    </DocsPage>
+  );
+}
+
+export { KeycloakDocs };
+export default KeycloakDocs;

--- a/docs/src/pages/docs/auth/use-auth.jsx
+++ b/docs/src/pages/docs/auth/use-auth.jsx
@@ -1,0 +1,110 @@
+import { Code, Text } from "@usace/groundwork";
+import ParamsTable from "../../components/params-table";
+import DocsPage from "../_docs-wrapper";
+import Divider from "../../components/divider";
+import QueryClientWarning from "../../../components/QueryClientWarning";
+import { AuthHookExample } from ".";
+
+const returnParams = [
+  {
+    name: "login",
+    type: "() => Promise<void>",
+    default: "undefined",
+    desc: "A function that handles user login with the authentication platform.",
+  },
+  {
+    name: "logout",
+    type: "() => Promise<void>",
+    default: "undefined",
+    desc: "A function that logs the user out of authentication platform.",
+  },
+  {
+    name: "isAuth",
+    type: "boolean",
+    default: "undefined",
+    desc: "True if user is authenticated, else false.",
+  },
+  {
+    name: "isLoading",
+    type: "boolean",
+    default: "undefined",
+    desc: "True if auth status is currently processing, else false.",
+  },
+  {
+    name: "token",
+    type: "string",
+    default: "undefined",
+    desc: "A string containing the user's access token, when available.",
+  },
+];
+
+const authProvider = (
+  <a href="/docs/auth/auth-provider" className="hover:underline">
+    <Code>&lt;AuthProvider&gt;</Code>
+  </a>
+);
+const authMethod = (
+  <a href="/docs/auth/auth-method" className="hover:underline">
+    <Code>AuthMethod</Code>
+  </a>
+);
+const useAuth = <Code>useAuth()</Code>;
+
+function UseAuthDocs() {
+  return (
+    <DocsPage middleText="{componentCode}">
+      <div>
+        <Text>
+          The {useAuth} hook provides access to your current authentication
+          context.
+        </Text>
+        <Text className="mt-4">
+          Any components that require access to authentication can tie in to the{" "}
+          {useAuth} hook. For example, these are some potential use cases:
+        </Text>
+        <ul className="list-disc mt-2 ml-8 text-gray-500">
+          <li>
+            a LoginButton component could attach the <Code>login</Code> function
+            to its onClick property
+          </li>
+          <li>
+            a component displayed only to authenticated users could toggle its
+            display based on the <Code>isAuth</Code> boolean
+          </li>
+          <li>
+            a component that fires a POST request could retrieve the{" "}
+            <Code>token</Code> string for inclusion in the request
+          </li>
+        </ul>
+        <Text className="mt-4">
+          In order for the {useAuth} hook to function correctly, it must be used
+          within a <Code>&lt;QueryClientProvider&gt;</Code> AND an{" "}
+          {authProvider}. The {authProvider} must be configured with an
+          appropriate {authMethod}.
+        </Text>
+        <QueryClientWarning />
+      </div>
+      <Divider text="Example Usage" className="mt-6 mb-4" />
+      <Text className="mt-2">
+        The following example expands upon the{" "}
+        <a
+          href="https://usace.github.io/groundwork/#/docs/buttons/login-button"
+          className="underline"
+        >
+          Groundwork LoginButton example
+        </a>{" "}
+        by incorporating our built-in authentication handling:
+      </Text>
+      <AuthHookExample />
+      <Divider text="API Reference" />
+      <div className="font-bold text-lg pt-6">
+        Return Parameters -{" "}
+        <Code className="p-2">{`const {...} = useAuth()`}</Code>
+      </div>
+      <ParamsTable paramsList={returnParams} showReq={false} />
+    </DocsPage>
+  );
+}
+
+export { UseAuthDocs };
+export default UseAuthDocs;

--- a/lib/components/data/utilities/auth/AuthProvider.tsx
+++ b/lib/components/data/utilities/auth/AuthProvider.tsx
@@ -10,7 +10,7 @@ export interface AuthMethod {
   refreshInterval?: number;
 }
 
-interface AuthContextValue {
+export interface AuthContextValue {
   login: () => Promise<void>;
   logout: () => Promise<void>;
   isAuth: boolean;

--- a/lib/components/data/utilities/auth/AuthProvider.tsx
+++ b/lib/components/data/utilities/auth/AuthProvider.tsx
@@ -1,0 +1,73 @@
+import { createContext, PropsWithChildren } from "react";
+import { useRefreshToken } from "./useRefreshToken";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+export interface AuthMethod {
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  isAuth: () => Promise<boolean>;
+  refresh?: () => Promise<void>;
+  refreshInterval?: number;
+}
+
+interface AuthContextValue {
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  isAuth: boolean;
+  isLoading: boolean;
+}
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  method: AuthMethod;
+  refreshInterval?: number;
+}
+
+export const AuthProvider = ({
+  method,
+  refreshInterval,
+  children,
+}: PropsWithChildren<AuthProviderProps>) => {
+  const {
+    data: isAuth = false,
+    isLoading,
+    refetch: refetchAuthStatus,
+  } = useQuery({
+    queryKey: ["auth", "status"],
+    queryFn: method.isAuth,
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+
+  useRefreshToken(isAuth, method, refreshInterval);
+
+  const login = useMutation({
+    mutationFn: method.login,
+    onSuccess: () => {
+      refetchAuthStatus();
+    },
+  });
+
+  const logout = useMutation({
+    mutationFn: method.logout,
+    onSuccess: () => {
+      refetchAuthStatus();
+    },
+  });
+
+  const isAnyLoading = isLoading || login.isPending || logout.isPending;
+
+  return (
+    <AuthContext.Provider
+      value={{
+        login: login.mutateAsync,
+        logout: logout.mutateAsync,
+        isAuth,
+        isLoading: isAnyLoading,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/lib/components/data/utilities/auth/AuthProvider.tsx
+++ b/lib/components/data/utilities/auth/AuthProvider.tsx
@@ -8,6 +8,7 @@ export interface AuthMethod {
   isAuth: () => Promise<boolean>;
   refresh?: () => Promise<void>;
   refreshInterval?: number;
+  token?: string;
 }
 
 export interface AuthContextValue {
@@ -15,6 +16,7 @@ export interface AuthContextValue {
   logout: () => Promise<void>;
   isAuth: boolean;
   isLoading: boolean;
+  token?: string;
 }
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
@@ -65,6 +67,7 @@ export const AuthProvider = ({
         logout: logout.mutateAsync,
         isAuth,
         isLoading: isAnyLoading,
+        token: method.token,
       }}
     >
       {children}

--- a/lib/components/data/utilities/auth/cwmsLoginAuthMethod.ts
+++ b/lib/components/data/utilities/auth/cwmsLoginAuthMethod.ts
@@ -1,0 +1,47 @@
+import { AuthMethod } from "./AuthProvider";
+
+interface CwmsLoginConfig {
+  authUrl: string;
+  authCheckUrl: string;
+}
+
+/**
+ * Generates a CWMSLogin authentation method from the provided configuration.
+ *
+ * The authUrl should point to the root of the CWMSLogin servlet, e.g.
+ * 'https://localhost:7000/CWMSLogin'.  The authCheckUrl will be used in a standard
+ * GET request and will return true if it receives an 'ok' response.  The
+ * CDA '/auth/keys' endpoint can be used for this purpose.
+ *
+ * @param {object} config - An object containing configuration details.
+ * @param {string} config.authUrl - The URL of the auth provider.
+ * @param {string} config.authCheckUrl - The URL of an endpoint to check auth status.
+ * @returns A CWMSLogin-based auth method for use in an AuthProvider.
+ */
+export const createCwmsLoginAuthMethod = ({
+  authUrl,
+  authCheckUrl,
+}: CwmsLoginConfig) => {
+  const cwmsLoginAuthMethod: AuthMethod = {
+    async login() {
+      location.href =
+        `${authUrl}/login?OriginalLocation=` +
+        encodeURIComponent(location.href);
+    },
+
+    async logout() {
+      location.href =
+        `${authUrl}/logout?OriginalLocation=` +
+        encodeURIComponent(location.href);
+    },
+
+    async isAuth() {
+      const keysRequest = await fetch(authCheckUrl, {
+        credentials: "include",
+      });
+      return keysRequest.ok;
+    },
+  };
+
+  return cwmsLoginAuthMethod;
+};

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -1,0 +1,138 @@
+import { AuthMethod } from "./AuthProvider";
+
+interface KeycloakTokenResponse {
+  access_token: string;
+  expires_in: number;
+  refresh_token: string;
+  refresh_expires_in: number;
+  id_token: string;
+  token_type: string;
+  not_before_policy: number;
+  session_state: string;
+  scope: string;
+}
+
+interface KeycloakOptions {
+  client_id: string;
+  grant_type?: "password" | "refresh_token";
+  scope?: string;
+  username?: string;
+  password?: string;
+  refresh_token?: string;
+}
+
+type KeycloakRequest = KeycloakOptions & Record<string, string>;
+
+interface KeycloakAuthConfig {
+  host: string;
+  realm: string;
+  client: string;
+  flow: "direct-grant";
+  refreshInterval?: number;
+}
+
+/**
+ * Generates a Keycloak authentation method from the provided configuration.
+ *
+ * The host should point to the root of the Keycloak provider, e.g.
+ * 'https://localhost:8080/auth'.
+ *
+ * @param {object} config - An object containing configuration details.
+ * @param {string} config.host - The root URL of the Keycloak auth provider.
+ * @param {string} config.realm - The Keycloak realm to use for authentication.
+ * @param {string} config.client - The Keycloak client to use for authentication.
+ * @param {string} config.flow - The Keycloak flow type to use for authentication.
+ * @param {number} config.refreshInterval - Time between each token refresh, in seconds.
+ */
+export const createKeycloakAuthMethod = ({
+  host,
+  realm,
+  client,
+  flow,
+  refreshInterval = 300,
+}: KeycloakAuthConfig) => {
+  let accessToken: string | undefined;
+  let refreshToken: string | undefined;
+  const baseUrl = `${host}/realms/${realm}/protocol/openid-connect`;
+
+  const fetchKeycloakRequest = async (
+    endpoint: "token" | "logout",
+    formData: KeycloakRequest
+  ) => {
+    const fullUrl = `${baseUrl}/${endpoint}`;
+
+    const data = new URLSearchParams(formData);
+    const response = await fetch(fullUrl, {
+      method: "POST",
+      body: data,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Keycloak request error: HTTP ${response.status}`);
+    }
+    return response;
+  };
+
+  const login = async () => {
+    const loginData: KeycloakRequest | undefined =
+      flow === "direct-grant"
+        ? {
+            grant_type: "password",
+            client_id: client,
+            scope: "openid profile",
+            username: "",
+            password: "",
+          }
+        : undefined;
+    if (!loginData)
+      throw new Error("Invalid flow provided for keycloak auth config");
+    const tokenResponse = await fetchKeycloakRequest("token", loginData);
+    const tokenJson: KeycloakTokenResponse = await tokenResponse.json();
+    accessToken = tokenJson.access_token;
+    refreshToken = tokenJson.refresh_token;
+  };
+
+  const logout = async () => {
+    if (refreshToken) {
+      const logoutData: KeycloakRequest = {
+        client_id: client,
+        refresh_token: refreshToken,
+      };
+      const logoutResponse = await fetchKeycloakRequest("logout", logoutData);
+      if (logoutResponse.ok) console.log("Successfully logged out of keycloak");
+      else console.error("Bad response from keycloak logout request");
+    }
+    accessToken = undefined;
+    refreshToken = undefined;
+  };
+
+  const isAuth = async () => {
+    return !!accessToken;
+  };
+
+  const refresh = async () => {
+    if (!refreshToken)
+      throw new Error("Cannot refresh token; no existing refresh token found");
+    const refreshData: KeycloakRequest = {
+      client_id: client,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    };
+    const refreshResponse = await fetchKeycloakRequest("token", refreshData);
+    const tokenJson: KeycloakTokenResponse = await refreshResponse.json();
+    accessToken = tokenJson.access_token;
+    refreshToken = tokenJson.refresh_token;
+  };
+
+  const keycloakAuthMethod: AuthMethod = {
+    login,
+    logout,
+    isAuth,
+    refresh,
+    refreshInterval,
+  };
+
+  return keycloakAuthMethod;
+};

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -132,6 +132,9 @@ export const createKeycloakAuthMethod = ({
     isAuth,
     refresh,
     refreshInterval,
+    get token() {
+      return accessToken;
+    },
   };
 
   return keycloakAuthMethod;

--- a/lib/components/data/utilities/auth/useAuth.ts
+++ b/lib/components/data/utilities/auth/useAuth.ts
@@ -1,0 +1,9 @@
+import { AuthContext } from "./AuthProvider";
+import { useContext } from "react";
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context)
+    throw new Error("useAuth() only available inside an AuthProvider");
+  return context;
+};

--- a/lib/components/data/utilities/auth/useRefreshToken.ts
+++ b/lib/components/data/utilities/auth/useRefreshToken.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { AuthMethod } from "../auth/AuthProvider";
+
+export function useRefreshToken(
+  enabled: boolean,
+  method: AuthMethod,
+  refreshInterval?: number
+) {
+  const interval = refreshInterval ?? method.refreshInterval ?? 300;
+  return useQuery({
+    queryKey: ["auth", "refresh"],
+    queryFn: async () => {
+      if (!method.refresh) {
+        throw new Error("refreshToken is not implemented");
+      }
+      await method.refresh();
+      return true;
+    },
+    enabled: enabled && !!method.refresh,
+    refetchInterval: interval * 1000,
+    refetchIntervalInBackground: true,
+    retry: 2,
+    staleTime: Infinity,
+  });
+}

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -18,6 +18,13 @@ import useCdaTimeSeries from "./components/data/hooks/useCdaTimeSeries";
 import useCdaTimeSeriesGroup from "./components/data/hooks/useCdaTimeSeriesGroup";
 import useNwpsGauge from "./components/data/hooks/useNwpsGauge";
 import useNwpsGaugeData from "./components/data/hooks/useNwpsGaugeData";
+
+// auth
+import { AuthProvider } from "./components/data/utilities/auth/AuthProvider";
+import { useAuth } from "./components/data/utilities/auth/useAuth";
+import { createCwmsLoginAuthMethod } from "./components/data/utilities/auth/cwmsLoginAuthMethod";
+import { createKeycloakAuthMethod } from "./components/data/utilities/auth/keycloakAuthMethod";
+
 // import { helperFunction } from './utils/helpers';
 
 export {
@@ -34,5 +41,9 @@ export {
   useCdaTimeSeriesGroup,
   useNwpsGauge,
   useNwpsGaugeData,
+  AuthProvider,
+  useAuth,
+  createCwmsLoginAuthMethod,
+  createKeycloakAuthMethod,
 };
 // export { helperFunction };


### PR DESCRIPTION
Includes an `<AuthProvider>` component, a `useAuth` hook, and constructor functions for auth methods using both CWMSLogin and Keycloak.

Docs are WIP.

I'm not happy with where I put this (`/lib/components/data/utilities/auth`).  Technically the only component is `AuthProvider`.  Speaking of which, all of the data hooks are also under `/components`...  Might be time to discuss restructuring a little.