### PR TITLE
Revert library css filename to style.css

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
           fileName: (format) => `groundwork-water.${format}.js`,
           entry: "lib/index.jsx",
           formats: ["es", "umd"],
+          cssFileName: "style",
         },
         rollupOptions: {
           external: [


### PR DESCRIPTION
Vite 6 changed the default filename for exported css files to match the library name.  Reverting to style.css for backwards compatibility with existing apps.