### PR TITLE
Timeseries Location Levels

### DIFF
--- a/docs/src/pages/docs/plots/cwms-plot.jsx
+++ b/docs/src/pages/docs/plots/cwms-plot.jsx
@@ -47,6 +47,7 @@ const CWMSPlotExample = () => {
   const locationLevels = [
     {
       id: `${dam}.Elev.Inst.0.Top of Flood`,
+      units: "ft",
       traceOptions: {
         name: "Spillway",
         mode: "lines",
@@ -65,6 +66,7 @@ const CWMSPlotExample = () => {
     },
     {
       id: `${dam}.Elev.Inst.0.Top of Normal`,
+      units: "ft",
       traceOptions: {
         name: "Normal Pool",
         mode: "lines",
@@ -183,6 +185,7 @@ const CWMSPlotExample = () => {
   const locationLevels = [
     {
       id: \`\${dam}.Elev.Inst.0.Top of Flood\`,
+      units: "ft",
       traceOptions: {
         name: "Spillway",
         mode: "lines",
@@ -201,6 +204,7 @@ const CWMSPlotExample = () => {
     },
     {
       id: \`\${dam}.Elev.Inst.0.Top of Normal\`,
+      units: "ft",
       traceOptions: {
         name: "Normal Pool",
         mode: "lines",

--- a/docs/src/props-declarations/plots.jsx
+++ b/docs/src/props-declarations/plots.jsx
@@ -15,7 +15,7 @@ const cwmsPlotProps = [
     name: "unit",
     type: "string",
     default: "undefined",
-    desc: "Specifies the unit or unit system of the response. Options: 'EN', 'SI', specific units (e.g. 'ft')",
+    desc: "Specifies the unit or unit system of the timeSeries response. Options: 'EN', 'SI', specific units (e.g. 'ft')",
   },
   {
     name: "office",
@@ -34,6 +34,12 @@ const cwmsPlotProps = [
     type: "TraceData[]",
     default: "undefined",
     desc: "An array of objects that define the location level ids to plot and, optionally, styling options.  Details below.",
+  },
+  {
+    name: "units",
+    type: "string",
+    default: "undefined",
+    desc: "Specifies the units specific to the location level, e.g. 'ft'",
   },
   {
     name: "pageSize",


### PR DESCRIPTION
Change to using the Timeseries Location Level endpoint. Updates to CWMSPlot code and Docs as necessary.

Endpoint requires the units of the location level be specified - not just EN or SI but "ft" for example.

Using Timeseries Location Levels includes building array of datetime, level pairs with adjustments for the first and last entries (only) to match the exact range of the timeseries values data. Additional work may be undertaken to adjust the other items in that array to snap to more sensible values instead of the response from CDA which is based upon the timestamp of the request.

Separately, removed a block of code that was commented-out and was intended to handle the page size based on the time range and pathname interval. Now that page size is included as its own parameter, this is no longer necessary.