### PR TITLE
useCdaLatestValue - Fix shared state across tsIds for latestDate

### DIFF
--- a/lib/components/data/hooks/useCdaLatestValue.ts
+++ b/lib/components/data/hooks/useCdaLatestValue.ts
@@ -17,7 +17,9 @@ const useCdaLatestValue = ({
   unit,
   cdaUrl,
 }: useCdaLatestValueParams) => {
-  const [latestDate, setLatestDate] = useState<Record<string, string>>({});
+  const [latestDate, setLatestDate] = useState<
+    Record<string, string | undefined>
+  >({});
   const begin = latestDate[tsId];
   const end = latestDate[tsId];
   const ts = useCdaTimeSeries({


### PR DESCRIPTION
latestDate state was potentially set for a tsId and not recomputed when the tsId of the hook changes, causing tsIds with current data to report past data.  Change state to an object that references each tsId individually.

This hook could probably do with an overhaul at some point -- it was already somewhat convoluted and this makes it more so.  I think it could potentially be streamlined and have the state and useEffect removed entirely.  But it works as is for the time being, so down the priority list it goes.