### PR TITLE
Add TimeSeries hook for MIDAS instrumentation data

### DIFF
--- a/docs/.env.development
+++ b/docs/.env.development
@@ -1,0 +1,1 @@
+VITE_MIDAS_API_URL='/midas-api'

--- a/docs/.env.production
+++ b/docs/.env.production
@@ -1,0 +1,1 @@
+VITE_MIDAS_API_URL='https://midas.sec.usace.army.mil/api'

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,7 +6,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
-*.env*
 
 node_modules
 dist

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -28,6 +28,7 @@ import HelpPage from "../pages/docs/help";
 import CdaUrlProviderDocs from "../pages/docs/utilities/cda-url-provider";
 import UtilitiesDocs from "../pages/docs/utilities";
 import UseCdaLevels from "../pages/docs/hooks/use-cda-levels";
+import UseMidasProjectTS from "../pages/docs/hooks/use-midas-time-series";
 
 export default createRouteBundle(
   {
@@ -50,6 +51,7 @@ export default createRouteBundle(
     "/docs/hooks/use-cda-time-series-group": UseCdaTimeSeriesGroup,
     "/docs/hooks/use-nwps-gauge": UseNwpsGauge,
     "/docs/hooks/use-nwps-gauge-data": UseNwpsGaugeData,
+    "/docs/hooks/use-midas-ts": UseMidasProjectTS,
     "/docs/plots": PlotsDocs,
     "/docs/plots/cwms-plot": CWMSPlotDocs,
     "/docs/maps": Maps,

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -98,6 +98,11 @@ export default [
         text: "NWPS Gauge Data",
         href: "/docs/hooks/use-nwps-gauge-data",
       },
+      {
+        id: "use-midas-ts",
+        text: "MIDAS Project Time Series",
+        href: "/docs/hooks/use-midas-ts",
+      },
     ],
   },
   {

--- a/docs/src/pages/docs/hooks/use-midas-time-series.jsx
+++ b/docs/src/pages/docs/hooks/use-midas-time-series.jsx
@@ -1,0 +1,123 @@
+import { H3, Text, Card, Code } from "@usace/groundwork";
+import DocsPage from "../_docs-wrapper";
+import ParamsTable from "../../components/params-table";
+import QueryClientWarning from "../../../components/QueryClientWarning";
+import Divider from "../../components/divider";
+import { Code as CodeBlock } from "../../components/code";
+import { queryOptionsParam } from "../../components/shared-docs";
+import { useMidasProjectTS } from "../../../../../lib/components/data/hooks/useMidasTS";
+
+const hookParams = [
+  {
+    name: "project",
+    type: "string",
+    required: true,
+    desc: "The MIDAS project ID (UUID) to retrieve timeseries data for.",
+  },
+  {
+    name: "instrument",
+    type: "string",
+    required: true,
+    desc: "The MIDAS instrument ID (UUID) associated with the project.",
+  },
+  queryOptionsParam,
+];
+
+const MidasTimeseriesCard = () => {
+  const { data, isPending, isError } = useMidasProjectTS({
+    project: "6de30cf7-e205-42dd-a23c-5ad8f9186725",
+    instrument: "6e306cf2-c7a5-4251-8a01-690f60a482c6",
+    queryOptions: {
+      retry: 0,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  });
+
+  if (isPending) return <span>Loading MIDAS timeseries data...</span>;
+  if (isError) return <span>Error loading MIDAS data.</span>;
+
+  return (
+    <Card>
+      <H3>P-5 Instrument Time Series</H3>
+      <ul>
+        {data?.slice(0, 5).map((ts) => (
+          <li key={ts.id}>
+            <strong>{ts.name}</strong> – {ts.parameter} ({ts.unit})
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+};
+
+function UseMidasProjectTS() {
+  return (
+    <DocsPage middleText="MIDAS Project Time Series Hook">
+      <div>
+        <Text>
+          <div>
+            <Text>
+              <strong>MIDAS</strong> (Monitoring Instrumentation Data Acquisition
+              System) is the U.S. Army Corps of Engineers&apos; centralized platform for
+              storing and managing field instrumentation data at water resource projects
+              such as dams, levees, and reservoirs.
+            </Text>
+            <Text className="mt-4">
+              Each project in MIDAS may have one or more <strong>instruments</strong>{" "}
+              (e.g. piezometers, GPS sensors, inclinometers), and each instrument can
+              produce one or more <strong>time series</strong> — representing either
+              measured or computed values over time.
+            </Text>
+            <Text className="mt-4">
+              The <Code>useMidasProjectTS</Code> hook fetches the metadata for all time
+              series associated with a specific instrument at a given project. This
+              metadata includes the time series name, type (standard, computed, or
+              constant), unit, parameter, and variable identifier — all of which are
+              necessary for querying and visualizing data.
+            </Text>
+            <Text className="mt-4">
+              This hook is useful when building UIs that allow users to select from
+              available MIDAS time series or when integrating MIDAS data into Groundwork
+              applications.
+            </Text>
+          </div>
+        </Text>
+        <QueryClientWarning />
+      </div>
+      <Divider text="Example Usage" className="mt-8" />
+      <div className="rounded-md border border-dashed px-6 py-3 my-3">
+        <MidasTimeseriesCard />
+      </div>
+      <CodeBlock language="tsx">
+        {`import { useMidasProjectTS } from "@usace-watermanagement/groundwork-water";
+
+const MyComponent = () => {
+  const { data, isPending, isError } = useMidasProjectTS({
+    project: "6de30cf7-e205-42dd-a23c-5ad8f9186725",
+    instrument: "6e306cf2-c7a5-4251-8a01-690f60a482c6",
+  });
+
+  if (isPending) return <span>Loading...</span>;
+  if (isError) return <span>Error loading data.</span>;
+
+  return (
+    <ul>
+      {data?.map((ts) => (
+        <li key={ts.id}>{ts.name} ({ts.variable})</li>
+      ))}
+    </ul>
+  );
+};`}
+      </CodeBlock>
+      <Divider text="API Reference" className="mt-8" />
+      <div className="font-bold text-lg pt-6">
+        Hook Parameters - <Code className="p-2">{`useMidasProjectTS({...})`}</Code>
+      </div>
+      <ParamsTable paramsList={hookParams} />
+    </DocsPage>
+  );
+}
+
+export { UseMidasProjectTS };
+export default UseMidasProjectTS;

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -14,5 +14,14 @@ export default defineConfig(({ mode }) => {
     define: {
       "import.meta.env.PKG_VERSION": JSON.stringify(pkg.version),
     },
+    server: {
+      proxy: {
+        "/midas-api": {
+          target: "https://midas.sec.usace.army.mil",
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/midas-api/, "/api"),
+        },
+      },
+    },
   };
 });

--- a/lib/components/data/helpers/midas.js
+++ b/lib/components/data/helpers/midas.js
@@ -1,2 +1,2 @@
 export const MIDAS_VERSION = "v4";
-export const MIDAS_URL = `https://midas.sec.usace.army.mil/api/${MIDAS_VERSION}`
+export const MIDAS_URL = `/midas-api/${MIDAS_VERSION}`;

--- a/lib/components/data/helpers/midas.js
+++ b/lib/components/data/helpers/midas.js
@@ -1,2 +1,4 @@
+const midasUrl = import.meta.env.VITE_MIDAS_API_URL;
+
 export const MIDAS_VERSION = "v4";
-export const MIDAS_URL = `/midas-api/${MIDAS_VERSION}`;
+export const MIDAS_URL = `${midasUrl}/${MIDAS_VERSION}`;

--- a/lib/components/data/helpers/midas.js
+++ b/lib/components/data/helpers/midas.js
@@ -1,0 +1,2 @@
+export const MIDAS_VERSION = "v4";
+export const MIDAS_URL = `https://midas.sec.usace.army.mil/api/${MIDAS_VERSION}`

--- a/lib/components/data/hooks/useMidasTS.ts
+++ b/lib/components/data/hooks/useMidasTS.ts
@@ -1,0 +1,37 @@
+import { UseQueryOptions, useQuery } from "@tanstack/react-query";
+import { MIDAS_URL } from "../helpers/midas";
+import { MidasTimeSeries } from "../../../types/midas";
+
+const getMidasProjectTimeSeries = async (
+  project: string,
+  instrument: string
+): Promise<MidasTimeSeries[]> => {
+  const response = await fetch(
+    `${MIDAS_URL}/projects/${project}/instruments/${instrument}/timeseries`
+  );
+  if (!response.ok) {
+    throw new Error("Error retrieving data");
+  }
+  return await response.json();
+};
+
+interface useMidasProjectParams {
+  project: string;
+  instrument: string;
+  queryOptions?: Partial<UseQueryOptions<MidasTimeSeries[]>>;
+}
+
+const useMidasProjectTS = ({
+  project,
+  instrument,
+  queryOptions = {},
+}: useMidasProjectParams) => {
+  return useQuery({
+    queryKey: ["midas", project, instrument],
+    queryFn: () => getMidasProjectTimeSeries(project, instrument),
+    ...queryOptions,
+  });
+};
+
+export { useMidasProjectTS };
+export default useMidasProjectTS;

--- a/lib/components/data/hooks/useMidasTS.ts
+++ b/lib/components/data/hooks/useMidasTS.ts
@@ -1,13 +1,12 @@
 import { UseQueryOptions, useQuery } from "@tanstack/react-query";
 import { MIDAS_URL } from "../helpers/midas";
-import { MidasTimeSeries } from "../../../types/midas";
 
 const getMidasProjectTimeSeries = async (
   project: string,
-  instrument: string
+  instrument: string,
 ): Promise<MidasTimeSeries[]> => {
   const response = await fetch(
-    `${MIDAS_URL}/projects/${project}/instruments/${instrument}/timeseries`
+    `${MIDAS_URL}/projects/${project}/instruments/${instrument}/timeseries`,
   );
   if (!response.ok) {
     throw new Error("Error retrieving data");
@@ -32,6 +31,22 @@ const useMidasProjectTS = ({
     ...queryOptions,
   });
 };
+
+interface MidasTimeSeries {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  is_computed: boolean;
+  variable: string;
+  instrument_id: string;
+  instrument_slug: string;
+  instrument: string;
+  parameter_id: string;
+  parameter: string;
+  unit_id: string;
+  unit: string;
+}
 
 export { useMidasProjectTS };
 export default useMidasProjectTS;


### PR DESCRIPTION
Speaking with @tsressin about using this I thought it might be nice to share this with the community. 

If we decide this does not belong here we do not need to merge in. 

However, if this seems useful in our meeting we can also potentially add other endpoints. 

Testing:

I was unable to get the reverse proxy to MIDAS API to work within vite. But this may work on the github site pending MIDAS does not have CORS blocking it. 