### PR TITLE
Add husky to npm prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "build-docs": "cd docs && vite build",
     "build-docs-prod": "cd docs && vite build",
     "deploy": "gh-pages -d dist",
+    "prepare": "husky",
     "login": "npm login"
   },
   "lint-staged": {


### PR DESCRIPTION
Fixes bug in which husky scripts were not properly installed by default.

It was working locally for me but I didn't catch that it didn't properly install for other users upon "npm install".