### PR TITLE
Change .at(0) syntax to [0]

### DIFF
--- a/lib/components/data/dropdowns/OfficeDropdown.tsx
+++ b/lib/components/data/dropdowns/OfficeDropdown.tsx
@@ -89,7 +89,7 @@ const OfficeDropdown = ({
       ) : (
         <Dropdown
           className={"gww-w-5/6 gww-m-auto"}
-          defaultValue={filteredOffices.at(0)?.name}
+          defaultValue={filteredOffices[0]?.name}
           title="Select an office"
           aria-label="Select an office"
           options={filteredOffices.map((office) => (


### PR DESCRIPTION
.at() is not supported until ES2022

Submitting without changeset to incorporate with previous version