### PR TITLE
Fix BasePATH in URL docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -101,6 +101,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1517,7 +1518,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
       "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -1658,6 +1658,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1761,6 +1762,7 @@
       "resolved": "https://registry.npmjs.org/@usace/groundwork/-/groundwork-3.14.19.tgz",
       "integrity": "sha512-gOhffV3cnss44YNPI/JTCklQ9w1hstbwHKC/Q7xzQfApXDzKZnJuYLsdEONfIybCMXxgQDg+Xreh591tD40wlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@headlessui/react": "^2.2.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1802,6 +1804,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2155,6 +2158,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2917,6 +2921,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5025,6 +5030,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5281,6 +5287,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5293,6 +5300,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5369,7 +5377,8 @@
       "version": "28.1.0",
       "resolved": "https://registry.npmjs.org/redux-bundler/-/redux-bundler-28.1.0.tgz",
       "integrity": "sha512-dbq0J0Sm0ctK9ZUh73JR/6J937qzNvkKEHXtHv7p2Hl/9sS+xyRQReWjuju8LHopYFiG+U0Lg9XZM1hPp1WkHg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-bundler-hook": {
       "version": "1.0.3",
@@ -6154,6 +6163,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6272,6 +6282,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6488,6 +6499,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6578,6 +6590,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/docs/src/pages/docs/index.jsx
+++ b/docs/src/pages/docs/index.jsx
@@ -3,6 +3,8 @@ import { Code } from "../components/code";
 import CopyButton from "../../components/CopyButton";
 import DocsPage from "./_docs-wrapper";
 
+const BASE_URL = import.meta.env.BASE_URL;
+
 export default function Docs() {
   return (
     <DocsPage
@@ -37,7 +39,7 @@ export default function Docs() {
               Vite documentation
             </a>{" "}
             for more details on getting started or visit the{" "}
-            <a className="gw-underline" href="/docs/quick-start">
+            <a className="gw-underline" href={`${BASE_URL}#/docs/quick-start`}>
               quick start guide
             </a>{" "}
             for a step by step guide for getting set up using Vite with Groundwork.


### PR DESCRIPTION
Did a `npm install` in the docs and it bumped the package lock

I did not bump the version as this is a docs only fix

Drafting this until i'm done with the Groundwork proper updates, in case I catch a few more.