### PR TITLE
Upgrade trusted publishing node version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org/"
 
       - run: npm ci


### PR DESCRIPTION
Use node 24 for trusted publishing (requires at least 22)