### PR TITLE
132 migrate keycloak auth method to auth code pkce

### DIFF
--- a/.changeset/spicy-schools-marry.md
+++ b/.changeset/spicy-schools-marry.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add Keycloak Auth Code + PKCE support while retaining the legacy direct-grant flow.

--- a/docs/src/pages/docs/auth/index.jsx
+++ b/docs/src/pages/docs/auth/index.jsx
@@ -101,6 +101,11 @@ function AuthenticationDocs() {
             needed
           </li>
         </ul>
+        <Text className="mt-4">
+          For Keycloak integrations, Auth Code + PKCE is the preferred flow. This keeps
+          credential entry within Keycloak rather than passing usernames and passwords
+          directly through the application.
+        </Text>
         <QueryClientWarning />
       </div>
       <Divider text="Setup" className="mt-6 mb-4" />

--- a/docs/src/pages/docs/auth/keycloak.jsx
+++ b/docs/src/pages/docs/auth/keycloak.jsx
@@ -30,19 +30,37 @@ const componentProps = [
     name: "flow",
     type: "string",
     default: "undefined",
-    desc: "The authentication flow to use.  Currently only 'direct-grant' is supported.",
+    desc: "The authentication flow to use. Use 'authorization-code-pkce' for the redirect-based OIDC flow, or 'direct-grant' for the legacy password grant flow.",
+  },
+  {
+    name: "redirectUri",
+    type: "string",
+    default: "current page URL without query params",
+    desc: "Optional - Redirect URI used by the PKCE flow.",
+  },
+  {
+    name: "postLogoutRedirectUri",
+    type: "string",
+    default: "redirectUri",
+    desc: "Optional - Redirect URI used after PKCE logout.",
+  },
+  {
+    name: "scope",
+    type: "string",
+    default: '"openid profile"',
+    desc: "Optional - OIDC scopes requested by the PKCE flow.",
   },
   {
     name: "username",
     type: "string",
     default: '""',
-    desc: "(DEVELOPMENT-USE ONLY) The username to use for login. Defaults to blank.",
+    desc: "(DIRECT-GRANT ONLY) The username to use for login. Defaults to blank.",
   },
   {
-    name: "flow",
+    name: "password",
     type: "string",
     default: '""',
-    desc: "(DEVELOPMENT-USE ONLY) The password to use for login. Defaults to blank.",
+    desc: "(DIRECT-GRANT ONLY) The password to use for login. Defaults to blank.",
   },
   {
     name: "refreshInterval",
@@ -70,7 +88,7 @@ function KeycloakDocs() {
         <Text className="mt-4">
           The function must be passed a configuration object identifying the host URL,
           realm, client, authentication flow, and optionally a custom refresh interval
-          for refresh token requests.
+          for refresh token requests. The recommended flow is Auth Code + PKCE.
         </Text>
         <Text className="mt-4">
           This authentication method uses refresh tokens and will automatically manage
@@ -85,15 +103,13 @@ function KeycloakDocs() {
         </Text>
         <Text className="mt-4">
           <Alert
-            title={"Warning"}
-            status={"warning"}
-            message={
-              "A username and password can optionally be provided directly to the auth handler, but are intended for development purposes and should not be used in production."
-            }
+            title={"Flow Guidance"}
+            status={"info"}
+            message={"Prefer the PKCE flow so credential entry stays within Keycloak."}
           >
-            A username and password can optionally be provided directly to the auth
-            handler, but this is intended for development purposes and should not be
-            used in production.
+            The legacy direct-grant flow remains available, but PKCE is the preferred
+            path. Direct username/password values should be treated as a compatibility
+            option rather than the default.
           </Alert>
         </Text>
       </div>
@@ -107,12 +123,13 @@ const authMethod = createKeycloakAuthMethod({
   host: authHost,
   realm: "cwms",
   client: "cwms",
-  flow: "direct-grant",
+  flow: "authorization-code-pkce",
+  redirectUri: window.location.origin,
 });`}
       </CodeBlock>
       <Divider text="API Reference" className="mt-6" />
       <div className="font-bold text-lg pt-6">
-        config - <Code className="p-2">{`createCwmsLoginAuthMethod(config)`}</Code>
+        config - <Code className="p-2">{`createKeycloakAuthMethod(config)`}</Code>
       </div>
       <PropsTable propsList={componentProps} />
     </DocsPage>

--- a/docs/src/pages/docs/auth/keycloak.jsx
+++ b/docs/src/pages/docs/auth/keycloak.jsx
@@ -12,7 +12,7 @@ const componentProps = [
     name: "host",
     type: "string",
     default: "undefined",
-    desc: "The URL for the Keycloak instance",
+    desc: "The Keycloak base URL for your environment. Include '/auth' when your realm endpoints are served under that path.",
   },
   {
     name: "realm",
@@ -49,6 +49,12 @@ const componentProps = [
     type: "string",
     default: '"openid profile"',
     desc: "Optional - OIDC scopes requested by the PKCE flow.",
+  },
+  {
+    name: "providerHint",
+    type: "string",
+    default: "undefined",
+    desc: "Optional - Keycloak identity provider hint sent as kc_idp_hint.",
   },
   {
     name: "username",
@@ -91,6 +97,12 @@ function KeycloakDocs() {
           for refresh token requests. The recommended flow is Auth Code + PKCE.
         </Text>
         <Text className="mt-4">
+          Use the exact Keycloak base path that serves your realm endpoints. For the
+          CWBI test environment used by <Code>cwms-cli</Code>, that is
+          <Code> https://identity-test.cwbi.us/auth</Code> rather than the stripped root
+          URL.
+        </Text>
+        <Text className="mt-4">
           This authentication method uses refresh tokens and will automatically manage
           requests and updates for the current access token. The interval between
           refresh requests can be controlled by the refreshInterval option.
@@ -120,11 +132,12 @@ function KeycloakDocs() {
 // Set authHost from environment variables
 
 const authMethod = createKeycloakAuthMethod({
-  host: authHost,
-  realm: "cwms",
+  host: "https://identity-test.cwbi.us/auth",
+  realm: "cwbi",
   client: "cwms",
   flow: "authorization-code-pkce",
   redirectUri: window.location.origin,
+  providerHint: "federation-eams",
 });`}
       </CodeBlock>
       <Divider text="API Reference" className="mt-6" />

--- a/docs/src/pages/docs/forms/interactive-test.jsx
+++ b/docs/src/pages/docs/forms/interactive-test.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Text, Code, Input, Button } from "@usace/groundwork";
 import {
   CWMSForm,
@@ -15,6 +15,68 @@ import {
 } from "@usace-watermanagement/groundwork-water";
 import DocsPage from "../_docs-wrapper";
 import Divider from "../../components/divider";
+
+const INTERACTIVE_TEST_STORAGE_KEY = "groundwork-water:interactive-auth-config";
+
+const getInteractiveTestRedirectUri = () => {
+  if (typeof window === "undefined") return "";
+
+  const url = new URL(window.location.href);
+  url.search = "";
+
+  if (!url.hash || url.hash === "#") {
+    url.hash = "#/docs/forms/interactive-test";
+  }
+
+  return url.toString();
+};
+
+const getDefaultInteractiveConfig = () => {
+  const redirectUri = getInteractiveTestRedirectUri();
+
+  return {
+    authMethod: "keycloak",
+    testCdaUrl: "https://water.dev.cwbi.us/cwms-data",
+    keycloakConfig: {
+      host: "https://identity-test.cwbi.us/auth",
+      realm: "cwbi",
+      client: "cwms",
+      flow: "authorization-code-pkce",
+      redirectUri,
+      postLogoutRedirectUri: redirectUri,
+      scope: "openid profile",
+      providerHint: "federation-eams",
+    },
+  };
+};
+
+const normalizeInteractiveKeycloakConfig = (keycloakConfig, defaultConfig) => {
+  if (!keycloakConfig) return defaultConfig;
+
+  const normalized = {
+    ...defaultConfig,
+    ...keycloakConfig,
+  };
+
+  const normalizedHost = normalized.host?.trim().replace(/\/$/, "");
+
+  if (
+    normalizedHost === "https://identityc-test.cwbi.us" ||
+    normalizedHost === "https://identity-test.cwbi.us"
+  ) {
+    normalized.host = "https://identity-test.cwbi.us/auth";
+  }
+
+  if (normalized.realm === "cwms") {
+    normalized.realm = "cwbi";
+  }
+
+  if (!normalized.providerHint) {
+    normalized.providerHint = defaultConfig.providerHint;
+  }
+
+  return normalized;
+};
 
 // Inner component that uses auth context
 function InteractiveTestContent({ authMethod, testCdaUrl, setTestCdaUrl }) {
@@ -702,19 +764,51 @@ function InteractiveTestContent({ authMethod, testCdaUrl, setTestCdaUrl }) {
 
 // Main component with AuthProvider wrapper
 function InteractiveFormTest() {
-  const [authMethod, setAuthMethod] = useState("keycloak");
-  const [testCdaUrl, setTestCdaUrl] = useState("http://localhost:8081/cwms-data");
-  const [keycloakConfig, setKeycloakConfig] = useState({
-    host: "http://localhost:8081/auth",
-    realm: "cwms",
-    client: "cwms",
-    flow: "authorization-code-pkce",
-  });
+  const defaultConfig = useMemo(() => getDefaultInteractiveConfig(), []);
+  const [authMethod, setAuthMethod] = useState(defaultConfig.authMethod);
+  const [testCdaUrl, setTestCdaUrl] = useState(defaultConfig.testCdaUrl);
+  const [keycloakConfig, setKeycloakConfig] = useState(defaultConfig.keycloakConfig);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const savedConfig = window.localStorage.getItem(INTERACTIVE_TEST_STORAGE_KEY);
+    if (!savedConfig) return;
+
+    try {
+      const parsed = JSON.parse(savedConfig);
+      if (parsed.authMethod) setAuthMethod(parsed.authMethod);
+      if (parsed.testCdaUrl) setTestCdaUrl(parsed.testCdaUrl);
+      if (parsed.keycloakConfig) {
+        setKeycloakConfig(
+          normalizeInteractiveKeycloakConfig(
+            parsed.keycloakConfig,
+            defaultConfig.keycloakConfig,
+          ),
+        );
+      }
+    } catch (error) {
+      console.warn("Failed to load interactive auth config from localStorage", error);
+    }
+  }, [defaultConfig.keycloakConfig]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    window.localStorage.setItem(
+      INTERACTIVE_TEST_STORAGE_KEY,
+      JSON.stringify({
+        authMethod,
+        testCdaUrl,
+        keycloakConfig,
+      }),
+    );
+  }, [authMethod, testCdaUrl, keycloakConfig]);
 
   // Check if we're already in an AuthProvider
   let hasAuthProvider = false;
   try {
-    const testAuth = useAuth();
+    useAuth();
     hasAuthProvider = true;
   } catch (e) {
     // No auth provider exists
@@ -731,56 +825,48 @@ function InteractiveFormTest() {
     );
   }
 
-  // Create auth method based on selection
-  let selectedAuthMethod;
+  const selectedAuthMethod = useMemo(() => {
+    if (authMethod === "cwms") {
+      const baseUrl = testCdaUrl.replace(/\/$/, "");
+      return createCwmsLoginAuthMethod({
+        authUrl: `${baseUrl}/auth`,
+        authCheckUrl: `${baseUrl}/auth/keys`,
+      });
+    }
 
-  if (authMethod === "cwms") {
-    const baseUrl = testCdaUrl.replace(/\/$/, "");
-    selectedAuthMethod = createCwmsLoginAuthMethod({
-      authUrl: `${baseUrl}/auth`,
-      authCheckUrl: `${baseUrl}/auth/keys`,
-    });
-  } else if (authMethod === "keycloak") {
-    selectedAuthMethod = createKeycloakAuthMethod(keycloakConfig);
-  } else {
-    // Custom inline auth method that doesn't redirect
-    const createInlineAuthMethod = () => {
-      let authState = { isAuthenticated: false, user: null };
+    if (authMethod === "keycloak") {
+      return createKeycloakAuthMethod({
+        ...keycloakConfig,
+        flow: "authorization-code-pkce",
+      });
+    }
 
-      // Listen for successful inline authentication
-      const handleAuthSuccess = (event) => {
-        authState.isAuthenticated = true;
-        authState.user = event.detail;
-      };
+    let authState = { isAuthenticated: false, user: null };
 
-      window.addEventListener("inline-auth-success", handleAuthSuccess);
-
-      return {
-        login: async () => {
-          // This will trigger the modal to show
-          // The actual authentication is handled in handleInlineAuth
-          window.dispatchEvent(new Event("show-inline-auth-modal"));
-          return Promise.resolve();
-        },
-        logout: async () => {
-          authState.isAuthenticated = false;
-          authState.user = null;
-          return Promise.resolve();
-        },
-        isAuth: async () => {
-          return authState.isAuthenticated;
-        },
-        getUser: async () => {
-          return authState.user;
-        },
-        cleanup: () => {
-          window.removeEventListener("inline-auth-success", handleAuthSuccess);
-        },
-      };
+    const handleAuthSuccess = (event) => {
+      authState.isAuthenticated = true;
+      authState.user = event.detail;
     };
 
-    selectedAuthMethod = createInlineAuthMethod();
-  }
+    window.addEventListener("inline-auth-success", handleAuthSuccess);
+
+    return {
+      login: async () => {
+        window.dispatchEvent(new Event("show-inline-auth-modal"));
+        return Promise.resolve();
+      },
+      logout: async () => {
+        authState.isAuthenticated = false;
+        authState.user = null;
+        return Promise.resolve();
+      },
+      isAuth: async () => authState.isAuthenticated,
+      getUser: async () => authState.user,
+      cleanup: () => {
+        window.removeEventListener("inline-auth-success", handleAuthSuccess);
+      },
+    };
+  }, [authMethod, keycloakConfig, testCdaUrl]);
 
   return (
     <div>
@@ -815,28 +901,84 @@ function InteractiveFormTest() {
         </div>
 
         {authMethod === "keycloak" && (
-          <div className="grid grid-cols-3 gap-2">
+          <div className="space-y-3">
+            <div className="grid grid-cols-3 gap-2">
+              <Input
+                value={keycloakConfig.host}
+                onChange={(e) =>
+                  setKeycloakConfig({ ...keycloakConfig, host: e.target.value })
+                }
+                placeholder="Keycloak URL"
+              />
+              <Input
+                value={keycloakConfig.realm}
+                onChange={(e) =>
+                  setKeycloakConfig({ ...keycloakConfig, realm: e.target.value })
+                }
+                placeholder="Realm"
+              />
+              <Input
+                value={keycloakConfig.client}
+                onChange={(e) =>
+                  setKeycloakConfig({ ...keycloakConfig, client: e.target.value })
+                }
+                placeholder="Client ID"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                value={keycloakConfig.redirectUri}
+                onChange={(e) =>
+                  setKeycloakConfig({ ...keycloakConfig, redirectUri: e.target.value })
+                }
+                placeholder="Redirect URI"
+              />
+              <Input
+                value={keycloakConfig.postLogoutRedirectUri}
+                onChange={(e) =>
+                  setKeycloakConfig({
+                    ...keycloakConfig,
+                    postLogoutRedirectUri: e.target.value,
+                  })
+                }
+                placeholder="Post-logout redirect URI"
+              />
+            </div>
+
             <Input
-              value={keycloakConfig.host}
+              value={keycloakConfig.scope}
               onChange={(e) =>
-                setKeycloakConfig({ ...keycloakConfig, host: e.target.value })
+                setKeycloakConfig({ ...keycloakConfig, scope: e.target.value })
               }
-              placeholder="Keycloak URL"
+              placeholder="OIDC scope"
             />
+
             <Input
-              value={keycloakConfig.realm}
+              value={keycloakConfig.providerHint ?? ""}
               onChange={(e) =>
-                setKeycloakConfig({ ...keycloakConfig, realm: e.target.value })
+                setKeycloakConfig({
+                  ...keycloakConfig,
+                  providerHint: e.target.value,
+                })
               }
-              placeholder="Realm"
+              placeholder="Provider hint (optional)"
             />
-            <Input
-              value={keycloakConfig.client}
-              onChange={(e) =>
-                setKeycloakConfig({ ...keycloakConfig, client: e.target.value })
-              }
-              placeholder="Client ID"
-            />
+
+            <div className="rounded border border-blue-200 bg-blue-50 p-3">
+              <Text className="text-sm font-semibold">PKCE Callback Route</Text>
+              <Text className="mt-1 text-sm">
+                Use the exact Keycloak base path your environment exposes. For the
+                working CWBI test setup, that is
+                <Code className="mx-1">https://identity-test.cwbi.us/auth</Code>
+                with realm <Code className="mx-1">cwbi</Code>.
+              </Text>
+              <Text className="mt-1 text-sm">
+                Register this URL in Keycloak for both the login callback and
+                post-logout redirect:
+              </Text>
+              <Code className="mt-2 block break-all">{keycloakConfig.redirectUri}</Code>
+            </div>
           </div>
         )}
 

--- a/docs/src/pages/docs/forms/interactive-test.jsx
+++ b/docs/src/pages/docs/forms/interactive-test.jsx
@@ -708,9 +708,7 @@ function InteractiveFormTest() {
     host: "http://localhost:8081/auth",
     realm: "cwms",
     client: "cwms",
-    flow: "direct-grant",
-    password: "m5hectest",
-    username: "m5hectest",
+    flow: "authorization-code-pkce",
   });
 
   // Check if we're already in an AuthProvider
@@ -849,7 +847,7 @@ function InteractiveFormTest() {
             {authMethod === "cwms" &&
               "🔄 CWMS Login will redirect to OAuth login page and back"}
             {authMethod === "keycloak" &&
-              "🔐 Keycloak SSO provides enterprise authentication"}
+              "🔐 Keycloak SSO will use the redirect-based PKCE flow"}
           </Text>
         </div>
       </div>

--- a/docs/vite.config.js
+++ b/docs/vite.config.js
@@ -2,12 +2,30 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import pkg from "../package.json";
 import tailwindcss from "tailwindcss";
+import { fileURLToPath, URL } from "node:url";
 
 export default defineConfig(({ mode }) => {
   const base = mode === "production" ? "/groundwork-water/" : "/";
+  const isDevelopment = mode === "development";
   return {
     plugins: [react(), tailwindcss()],
     base: base,
+    resolve: {
+      alias: isDevelopment
+        ? [
+            {
+              find: "@usace-watermanagement/groundwork-water/dist/style.css",
+              replacement: fileURLToPath(
+                new URL("../lib/css/tailwind.css", import.meta.url),
+              ),
+            },
+            {
+              find: "@usace-watermanagement/groundwork-water",
+              replacement: fileURLToPath(new URL("../lib/index.jsx", import.meta.url)),
+            },
+          ]
+        : [],
+    },
     define: {
       "import.meta.env.PKG_VERSION": JSON.stringify(pkg.version),
     },

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -100,6 +100,15 @@ export const createKeycloakAuthMethod = ({
     return params.has("code") && params.has("state");
   };
 
+  const clearPkceState = async () => {
+    accessToken = undefined;
+    refreshToken = undefined;
+    pkceCallbackHandled = false;
+
+    if (!oidcClient) return;
+    await oidcClient.removeUser();
+  };
+
   const fetchKeycloakRequest = async (
     endpoint: "token" | "logout",
     formData: KeycloakRequest,
@@ -172,12 +181,18 @@ export const createKeycloakAuthMethod = ({
     if (flow === "authorization-code-pkce") {
       if (!oidcClient) return false;
 
-      if (!pkceCallbackHandled && hasPkceCallbackParams()) {
-        await oidcClient.signinCallback();
-        pkceCallbackHandled = true;
-      }
+      try {
+        if (!pkceCallbackHandled && hasPkceCallbackParams()) {
+          await oidcClient.signinCallback();
+          pkceCallbackHandled = true;
+        }
 
-      return syncTokensFromOidcUser();
+        return syncTokensFromOidcUser();
+      } catch (error) {
+        console.error("Failed to process keycloak PKCE auth state", error);
+        await clearPkceState();
+        return false;
+      }
     }
 
     return !!accessToken;

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -70,6 +70,7 @@ export const createKeycloakAuthMethod = ({
 }: KeycloakAuthConfig) => {
   let accessToken: string | undefined;
   let refreshToken: string | undefined;
+  let pkceCallbackHandled = false;
   const baseUrl = `${host}/realms/${realm}/protocol/openid-connect`;
   const oidcClient =
     flow === "authorization-code-pkce"
@@ -161,8 +162,9 @@ export const createKeycloakAuthMethod = ({
     if (flow === "authorization-code-pkce") {
       if (!oidcClient) return false;
 
-      if (hasPkceCallbackParams()) {
+      if (!pkceCallbackHandled && hasPkceCallbackParams()) {
         await oidcClient.signinCallback();
+        pkceCallbackHandled = true;
       }
 
       return syncTokensFromOidcUser();

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -29,7 +29,7 @@ interface KeycloakAuthConfig {
   host: string;
   realm: string;
   client: string;
-  flow: KeycloakFlow;
+  flow?: KeycloakFlow;
   username?: string;
   password?: string;
   redirectUri?: string;
@@ -60,7 +60,7 @@ export const createKeycloakAuthMethod = ({
   host,
   realm,
   client,
-  flow,
+  flow = "authorization-code-pkce",
   username = "",
   password = "",
   redirectUri,
@@ -71,7 +71,7 @@ export const createKeycloakAuthMethod = ({
   let accessToken: string | undefined;
   let refreshToken: string | undefined;
   let pkceCallbackHandled = false;
-  const baseUrl = `${host}/realms/${realm}/protocol/openid-connect`;
+  const baseUrl = `${host.replace(/\/$/, "")}/realms/${realm}/protocol/openid-connect`;
   const oidcClient =
     flow === "authorization-code-pkce"
       ? createKeycloakOidcClient({

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -1,4 +1,5 @@
 import { AuthMethod } from "./AuthProvider";
+import { createKeycloakOidcClient } from "./keycloakOidcClient";
 
 interface KeycloakTokenResponse {
   access_token: string;
@@ -22,14 +23,18 @@ interface KeycloakOptions {
 }
 
 type KeycloakRequest = KeycloakOptions & Record<string, string>;
+type KeycloakFlow = "authorization-code-pkce" | "direct-grant";
 
 interface KeycloakAuthConfig {
   host: string;
   realm: string;
   client: string;
-  flow: "direct-grant";
+  flow: KeycloakFlow;
   username?: string;
   password?: string;
+  redirectUri?: string;
+  postLogoutRedirectUri?: string;
+  scope?: string;
   refreshInterval?: number;
 }
 
@@ -46,6 +51,9 @@ interface KeycloakAuthConfig {
  * @param {string} config.flow - The Keycloak flow type to use for authentication.
  * @param {string} config.username - The username to use for authentication, if required.
  * @param {string} config.password - The password to use for authentication, if required.
+ * @param {string} config.redirectUri - The redirect URI to use for PKCE callback handling.
+ * @param {string} config.postLogoutRedirectUri - The redirect URI to use after PKCE logout.
+ * @param {string} config.scope - The OIDC scope to request for PKCE authentication.
  * @param {number} config.refreshInterval - Time between each token refresh, in seconds.
  */
 export const createKeycloakAuthMethod = ({
@@ -55,11 +63,25 @@ export const createKeycloakAuthMethod = ({
   flow,
   username = "",
   password = "",
+  redirectUri,
+  postLogoutRedirectUri,
+  scope,
   refreshInterval = 300,
 }: KeycloakAuthConfig) => {
   let accessToken: string | undefined;
   let refreshToken: string | undefined;
   const baseUrl = `${host}/realms/${realm}/protocol/openid-connect`;
+  const oidcClient =
+    flow === "authorization-code-pkce"
+      ? createKeycloakOidcClient({
+          host,
+          realm,
+          client,
+          redirectUri,
+          postLogoutRedirectUri,
+          scope,
+        })
+      : undefined;
 
   const fetchKeycloakRequest = async (
     endpoint: "token" | "logout",
@@ -82,6 +104,12 @@ export const createKeycloakAuthMethod = ({
   };
 
   const login = async () => {
+    if (flow === "authorization-code-pkce") {
+      if (!oidcClient) throw new Error("Invalid PKCE auth client configuration");
+      await oidcClient.signinRedirect();
+      return;
+    }
+
     const loginData: KeycloakRequest | undefined =
       flow === "direct-grant"
         ? {

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -145,6 +145,16 @@ export const createKeycloakAuthMethod = ({
   };
 
   const logout = async () => {
+    if (flow === "authorization-code-pkce") {
+      accessToken = undefined;
+      refreshToken = undefined;
+      pkceCallbackHandled = false;
+
+      if (!oidcClient) throw new Error("Invalid PKCE auth client configuration");
+      await oidcClient.signoutRedirect();
+      return;
+    }
+
     if (refreshToken) {
       const logoutData: KeycloakRequest = {
         client_id: client,

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -105,6 +105,13 @@ export const createKeycloakAuthMethod = ({
     return params.has("code") && params.has("state");
   };
 
+  const hasPkceSignoutCallbackParams = () => {
+    if (typeof window === "undefined") return false;
+
+    const params = new URLSearchParams(window.location.search);
+    return !params.has("code") && params.has("state");
+  };
+
   const clearPkceState = async () => {
     accessToken = undefined;
     refreshToken = undefined;
@@ -190,6 +197,12 @@ export const createKeycloakAuthMethod = ({
         if (!pkceCallbackHandled && hasPkceCallbackParams()) {
           await oidcClient.signinCallback();
           pkceCallbackHandled = true;
+        }
+
+        if (!pkceCallbackHandled && hasPkceSignoutCallbackParams()) {
+          await oidcClient.signoutCallback();
+          pkceCallbackHandled = true;
+          await clearPkceState();
         }
 
         const user = await getOidcUser();

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -184,6 +184,17 @@ export const createKeycloakAuthMethod = ({
   };
 
   const refresh = async () => {
+    if (flow === "authorization-code-pkce") {
+      if (!oidcClient) throw new Error("Invalid PKCE auth client configuration");
+
+      await oidcClient.signinSilent();
+      const hasToken = await syncTokensFromOidcUser();
+      if (!hasToken) {
+        throw new Error("Unable to refresh PKCE auth session");
+      }
+      return;
+    }
+
     if (!refreshToken)
       throw new Error("Cannot refresh token; no existing refresh token found");
     const refreshData: KeycloakRequest = {

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -83,6 +83,22 @@ export const createKeycloakAuthMethod = ({
         })
       : undefined;
 
+  const syncTokensFromOidcUser = async () => {
+    if (!oidcClient) return false;
+
+    const user = await oidcClient.getUser();
+    accessToken = user?.access_token;
+    refreshToken = user?.refresh_token;
+    return !!user?.access_token;
+  };
+
+  const hasPkceCallbackParams = () => {
+    if (typeof window === "undefined") return false;
+
+    const params = new URLSearchParams(window.location.search);
+    return params.has("code") && params.has("state");
+  };
+
   const fetchKeycloakRequest = async (
     endpoint: "token" | "logout",
     formData: KeycloakRequest,
@@ -142,6 +158,16 @@ export const createKeycloakAuthMethod = ({
   };
 
   const isAuth = async () => {
+    if (flow === "authorization-code-pkce") {
+      if (!oidcClient) return false;
+
+      if (hasPkceCallbackParams()) {
+        await oidcClient.signinCallback();
+      }
+
+      return syncTokensFromOidcUser();
+    }
+
     return !!accessToken;
   };
 

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -25,6 +25,16 @@ interface KeycloakOptions {
 type KeycloakRequest = KeycloakOptions & Record<string, string>;
 type KeycloakFlow = "authorization-code-pkce" | "direct-grant";
 
+const AUTH_RESPONSE_PARAMS = [
+  "code",
+  "state",
+  "session_state",
+  "iss",
+  "error",
+  "error_description",
+  "error_uri",
+];
+
 interface KeycloakAuthConfig {
   host: string;
   realm: string;
@@ -112,6 +122,25 @@ export const createKeycloakAuthMethod = ({
     return !params.has("code") && params.has("state");
   };
 
+  const clearAuthResponseParams = () => {
+    if (typeof window === "undefined") return;
+
+    const url = new URL(window.location.href);
+    let hasChanges = false;
+
+    for (const param of AUTH_RESPONSE_PARAMS) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.delete(param);
+        hasChanges = true;
+      }
+    }
+
+    if (hasChanges) {
+      const nextUrl = `${url.pathname}${url.search}${url.hash}`;
+      window.history.replaceState(window.history.state, document.title, nextUrl);
+    }
+  };
+
   const clearPkceState = async () => {
     accessToken = undefined;
     refreshToken = undefined;
@@ -197,12 +226,14 @@ export const createKeycloakAuthMethod = ({
         if (!pkceCallbackHandled && hasPkceCallbackParams()) {
           await oidcClient.signinCallback();
           pkceCallbackHandled = true;
+          clearAuthResponseParams();
         }
 
         if (!pkceCallbackHandled && hasPkceSignoutCallbackParams()) {
           await oidcClient.signoutCallback();
           pkceCallbackHandled = true;
           await clearPkceState();
+          clearAuthResponseParams();
         }
 
         const user = await getOidcUser();

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -93,6 +93,11 @@ export const createKeycloakAuthMethod = ({
     return !!user?.access_token;
   };
 
+  const getOidcUser = async () => {
+    if (!oidcClient) return null;
+    return oidcClient.getUser();
+  };
+
   const hasPkceCallbackParams = () => {
     if (typeof window === "undefined") return false;
 
@@ -187,6 +192,20 @@ export const createKeycloakAuthMethod = ({
           pkceCallbackHandled = true;
         }
 
+        const user = await getOidcUser();
+        if (!user) {
+          accessToken = undefined;
+          refreshToken = undefined;
+          return false;
+        }
+
+        if (!user.expired) {
+          accessToken = user.access_token;
+          refreshToken = user.refresh_token;
+          return true;
+        }
+
+        await oidcClient.signinSilent();
         return syncTokensFromOidcUser();
       } catch (error) {
         console.error("Failed to process keycloak PKCE auth state", error);

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -1,5 +1,6 @@
 import { AuthMethod } from "./AuthProvider";
 import { createKeycloakOidcClient } from "./keycloakOidcClient";
+import { normalizeKeycloakHost } from "./keycloakHost";
 
 interface KeycloakTokenResponse {
   access_token: string;
@@ -45,17 +46,18 @@ interface KeycloakAuthConfig {
   redirectUri?: string;
   postLogoutRedirectUri?: string;
   scope?: string;
+  providerHint?: string;
   refreshInterval?: number;
 }
 
 /**
  * Generates a Keycloak authentation method from the provided configuration.
  *
- * The host should point to the root of the Keycloak provider, e.g.
- * 'https://localhost:8080/auth'.
+ * The host should point to the actual Keycloak base path for the target realm, e.g.
+ * 'https://localhost:8080/auth' when realm endpoints are served under '/auth'.
  *
  * @param {object} config - An object containing configuration details.
- * @param {string} config.host - The root URL of the Keycloak auth provider.
+ * @param {string} config.host - The base URL of the Keycloak auth provider.
  * @param {string} config.realm - The Keycloak realm to use for authentication.
  * @param {string} config.client - The Keycloak client to use for authentication.
  * @param {string} config.flow - The Keycloak flow type to use for authentication.
@@ -64,6 +66,7 @@ interface KeycloakAuthConfig {
  * @param {string} config.redirectUri - The redirect URI to use for PKCE callback handling.
  * @param {string} config.postLogoutRedirectUri - The redirect URI to use after PKCE logout.
  * @param {string} config.scope - The OIDC scope to request for PKCE authentication.
+ * @param {string} config.providerHint - Optional Keycloak identity provider hint, sent as kc_idp_hint.
  * @param {number} config.refreshInterval - Time between each token refresh, in seconds.
  */
 export const createKeycloakAuthMethod = ({
@@ -76,12 +79,14 @@ export const createKeycloakAuthMethod = ({
   redirectUri,
   postLogoutRedirectUri,
   scope,
+  providerHint,
   refreshInterval = 300,
 }: KeycloakAuthConfig) => {
   let accessToken: string | undefined;
   let refreshToken: string | undefined;
   let pkceCallbackHandled = false;
-  const baseUrl = `${host.replace(/\/$/, "")}/realms/${realm}/protocol/openid-connect`;
+  const normalizedHost = normalizeKeycloakHost(host);
+  const baseUrl = `${normalizedHost}/realms/${realm}/protocol/openid-connect`;
   const oidcClient =
     flow === "authorization-code-pkce"
       ? createKeycloakOidcClient({
@@ -91,6 +96,7 @@ export const createKeycloakAuthMethod = ({
           redirectUri,
           postLogoutRedirectUri,
           scope,
+          providerHint,
         })
       : undefined;
 

--- a/lib/components/data/utilities/auth/keycloakOidcClient.ts
+++ b/lib/components/data/utilities/auth/keycloakOidcClient.ts
@@ -1,0 +1,53 @@
+import { UserManager, UserManagerSettings, WebStorageStateStore } from "oidc-client-ts";
+
+export interface KeycloakPkceConfig {
+  host: string;
+  realm: string;
+  client: string;
+  redirectUri?: string;
+  postLogoutRedirectUri?: string;
+  scope?: string;
+}
+
+const getDefaultRedirectUri = () => {
+  if (typeof window === "undefined") return undefined;
+
+  const url = new URL(window.location.href);
+  url.search = "";
+  return url.toString();
+};
+
+export const createKeycloakOidcClient = ({
+  host,
+  realm,
+  client,
+  redirectUri,
+  postLogoutRedirectUri,
+  scope = "openid profile",
+}: KeycloakPkceConfig) => {
+  if (typeof window === "undefined") {
+    throw new Error("Keycloak PKCE auth requires a browser environment");
+  }
+
+  const resolvedRedirectUri = redirectUri ?? getDefaultRedirectUri();
+  if (!resolvedRedirectUri) {
+    throw new Error("Keycloak PKCE auth requires a redirect URI");
+  }
+
+  const settings: UserManagerSettings = {
+    authority: `${host.replace(/\/$/, "")}/realms/${realm}`,
+    client_id: client,
+    redirect_uri: resolvedRedirectUri,
+    post_logout_redirect_uri: postLogoutRedirectUri ?? resolvedRedirectUri,
+    response_type: "code",
+    scope,
+    automaticSilentRenew: false,
+    monitorSession: false,
+    userStore: new WebStorageStateStore({
+      prefix: `groundwork-water:keycloak:${realm}:${client}:`,
+      store: window.localStorage,
+    }),
+  };
+
+  return new UserManager(settings);
+};

--- a/lib/components/data/utilities/auth/keycloakOidcClient.ts
+++ b/lib/components/data/utilities/auth/keycloakOidcClient.ts
@@ -7,6 +7,7 @@ export interface KeycloakPkceConfig {
   redirectUri?: string;
   postLogoutRedirectUri?: string;
   scope?: string;
+  providerHint?: string;
 }
 
 const getDefaultRedirectUri = () => {
@@ -24,6 +25,7 @@ export const createKeycloakOidcClient = ({
   redirectUri,
   postLogoutRedirectUri,
   scope = "openid profile",
+  providerHint,
 }: KeycloakPkceConfig) => {
   if (typeof window === "undefined") {
     throw new Error("Keycloak PKCE auth requires a browser environment");
@@ -34,8 +36,10 @@ export const createKeycloakOidcClient = ({
     throw new Error("Keycloak PKCE auth requires a redirect URI");
   }
 
+  const normalizedHost = host.trim().replace(/\/$/, "");
+
   const settings: UserManagerSettings = {
-    authority: `${host.replace(/\/$/, "")}/realms/${realm}`,
+    authority: `${normalizedHost}/realms/${realm}`,
     client_id: client,
     redirect_uri: resolvedRedirectUri,
     post_logout_redirect_uri: postLogoutRedirectUri ?? resolvedRedirectUri,
@@ -47,6 +51,7 @@ export const createKeycloakOidcClient = ({
       prefix: `groundwork-water:keycloak:${realm}:${client}:`,
       store: window.localStorage,
     }),
+    extraQueryParams: providerHint ? { kc_idp_hint: providerHint } : undefined,
   };
 
   return new UserManager(settings);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@usace-watermanagement/groundwork-water",
-  "version": "3.6.0",
+  "version": "3.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@usace-watermanagement/groundwork-water",
-      "version": "3.6.0",
+      "version": "3.6.4",
       "license": "MIT",
       "dependencies": {
         "cwmsjs": "^2.3.0-2024.12.10",
         "dayjs": "^1.11.11",
         "deepmerge": "^4.3.1",
+        "oidc-client-ts": "^3.5.0",
         "ol": "^10.0.0",
         "plotly.js-basic-dist": "^2.33.0",
         "react-icons": "^5.3.0",
@@ -5647,6 +5648,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6157,6 +6167,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ol": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "cwmsjs": "^2.3.0-2024.12.10",
     "dayjs": "^1.11.11",
     "deepmerge": "^4.3.1",
+    "oidc-client-ts": "^3.5.0",
     "ol": "^10.0.0",
     "plotly.js-basic-dist": "^2.33.0",
     "react-icons": "^5.3.0",


### PR DESCRIPTION
 ## Summary                                                                                                          
                                                                                                                      
Update GWW Keycloak auth to support Auth Code + PKCE and makes PKCE the default flow, and allows direct-grant path available as a legacy fallback. (for now)                                           
                                                                                                                      
  It also updates the auth docs and interactive test page so they point people toward the PKCE flow instead of passing
  username/password directly.                                                                                         
                                                                                                                      
  Closes #132                                                                                                         
                                                                                                                      
  ## Changes                                                                                                          
                                                                                                                      
  - added [`oidc-client-ts`](https://authts.github.io/oidc-client-ts/) for Keycloak OIDC handling                                                                 
  - wired Keycloak auth into PKCE login, callback handling, logout, and silent refresh                                
  - defaulted `createKeycloakAuthMethod()` to `authorization-code-pkce`                                               
  - kept `direct-grant` for compatibility                                                                             
  - updated docs and examples to describe PKCE as the preferred path                                                  
                                                                                                                      
  ## Verification                                                                                                     

  - `npm.cmd run build`                                                                                               
  - `npm.cmd run build-docs`    
 
 
 Drafting until I can test this on localhost with access to Dev