### PR TITLE
Add reusable SearchInput component and docs

### DIFF
--- a/.changeset/spicy-ads-float.md
+++ b/.changeset/spicy-ads-float.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add a reusable `SearchInput` component and docs for district-configured search bars.

--- a/.changeset/witty-humans-swim.md
+++ b/.changeset/witty-humans-swim.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add search component

--- a/.changeset/witty-humans-swim.md
+++ b/.changeset/witty-humans-swim.md
@@ -1,5 +1,0 @@
----
-"@usace-watermanagement/groundwork-water": minor
----
-
-Add search component

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -17,6 +17,7 @@ import CwmsLoginDocs from "../pages/docs/auth/cwms-login";
 import KeycloakDocs from "../pages/docs/auth/keycloak";
 import UseAuthDocs from "../pages/docs/auth/use-auth";
 import OfficesDropdownDocs from "../pages/docs/dropdowns/offices";
+import SearchInputDocs from "../pages/docs/dropdowns/search-input";
 import UseCdaCatalog from "../pages/docs/hooks/use-cda-catalog";
 import UseCdaLatestValue from "../pages/docs/hooks/use-cda-latest-value";
 import UseCdaLocation from "../pages/docs/hooks/use-cda-location";
@@ -60,6 +61,7 @@ export default createRouteBundle(
     "/docs/auth/keycloak": KeycloakDocs,
     "/docs/auth/use-auth": UseAuthDocs,
     "/docs/dropdowns/offices": OfficesDropdownDocs,
+    "/docs/dropdowns/search-input": SearchInputDocs,
     "/docs/hooks": DataHooks,
     "/docs/hooks/use-cda-catalog": UseCdaCatalog,
     "/docs/hooks/use-cda-latest-value": UseCdaLatestValue,

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -62,6 +62,11 @@ export default [
     href: `${BASE_URL}#/docs/dropdowns`,
     children: [
       {
+        id: "search-input",
+        text: "Search Input",
+        href: `${BASE_URL}#/docs/dropdowns/search-input`,
+      },
+      {
         id: "offices",
         text: "Offices",
         href: `${BASE_URL}#/docs/dropdowns/offices`,

--- a/docs/src/pages/docs/dropdowns/search-input.jsx
+++ b/docs/src/pages/docs/dropdowns/search-input.jsx
@@ -1,5 +1,5 @@
 import { Badge, Card, Code, H3, Link, Text } from "@usace/groundwork";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { Code as CodeBlock } from "../../components/code";
 import Divider from "../../components/divider";
@@ -23,6 +23,18 @@ const propsList = [
     desc: "Initial uncontrolled query value. Default: empty string.",
   },
   {
+    name: "office",
+    type: "string",
+    required: false,
+    desc: "Office used by the built-in CDA location search. Example: 'SWT'.",
+  },
+  {
+    name: "cdaUrl",
+    type: "string",
+    required: false,
+    desc: "Base URL for the built-in CDA location search.",
+  },
+  {
     name: "onQueryChange",
     type: "(query: string) => void",
     required: false,
@@ -32,13 +44,13 @@ const propsList = [
     name: "onSearch",
     type: "(query: string) => void",
     required: false,
-    desc: "Debounced callback fired after debounceMs. Consumer code should fetch or filter results here.",
+    desc: "Debounced callback fired after debounceMs. If provided, it overrides the built-in CDA search.",
   },
   {
     name: "results",
     type: "T[]",
     required: false,
-    desc: "Search results to render in the dropdown. The component does not fetch data by itself.",
+    desc: "Optional externally managed results. When omitted, built-in CDA results can be used.",
   },
   {
     name: "onSelect",
@@ -86,7 +98,7 @@ const propsList = [
     name: "isLoading",
     type: "boolean",
     required: false,
-    desc: "Shows loading skeleton rows while results are being fetched.",
+    desc: "Optional external loading state. Useful when custom onSearch logic is supplied.",
   },
   {
     name: "idleMessage",
@@ -104,7 +116,7 @@ const propsList = [
     name: "errorMessage",
     type: "string",
     required: false,
-    desc: "Error text shown instead of the results list.",
+    desc: "Optional external error text. Useful when custom onSearch logic is supplied.",
   },
   {
     name: "label / placeholder / disabled / autoFocus",
@@ -122,20 +134,8 @@ const propsList = [
 
 const LiveExample = () => {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState([]);
   const [selected, setSelected] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
   const [office, setOffice] = useState("SWT");
-  const timeoutRef = useRef();
-  const abortRef = useRef();
-
-  useEffect(() => {
-    return () => {
-      window.clearTimeout(timeoutRef.current);
-      abortRef.current?.abort();
-    };
-  }, []);
 
   const selectedLabel = useMemo(() => {
     if (!selected) return "none";
@@ -145,11 +145,10 @@ const LiveExample = () => {
   return (
     <div className="flex flex-col gap-6">
       <Card className="w-full max-w-[720px]">
-        <H3>Async Search Pattern</H3>
+        <H3>Default CDA Search</H3>
         <p className="mb-3 text-sm">
-          This example uses the live CDA catalog endpoint that Lauren's MVP search is
-          built on. Pick an office with data, then search for a location like{" "}
-          <Code>KEYS</Code>.
+          This example uses the built-in CDA search path. Pick an office with data, then
+          search for a location like <Code>KEYS</Code>.
         </p>
         <div className="mb-4">
           <OfficeDropdown
@@ -158,64 +157,16 @@ const LiveExample = () => {
             onChange={(event) => {
               setOffice(event.target.value);
               setSelected(null);
-              setResults([]);
-              setErrorMessage("");
             }}
           />
         </div>
         <SearchInput
           label={`Search ${office} locations`}
+          office={office}
+          cdaUrl={CDA_URL}
           query={query}
           onQueryChange={setQuery}
-          results={results}
-          isLoading={isLoading}
-          errorMessage={errorMessage}
           minQueryLength={3}
-          onSearch={(nextQuery) => {
-            window.clearTimeout(timeoutRef.current);
-            abortRef.current?.abort();
-            if (nextQuery.trim().length < 3) {
-              setResults([]);
-              setIsLoading(false);
-              setErrorMessage("");
-              return;
-            }
-
-            setIsLoading(true);
-            setErrorMessage("");
-            timeoutRef.current = window.setTimeout(() => {
-              const controller = new AbortController();
-              abortRef.current = controller;
-              fetch(
-                `${CDA_URL}/catalog/LOCATIONS?office=${office}&like=${encodeURIComponent(nextQuery)}`,
-                {
-                  method: "GET",
-                  headers: { Accept: "application/json" },
-                  signal: controller.signal,
-                },
-              )
-                .then(async (response) => {
-                  if (!response.ok) {
-                    throw new Error(
-                      `CDA search failed: ${response.status} ${response.statusText}`,
-                    );
-                  }
-                  return response.json();
-                })
-                .then((data) => {
-                  const entries = Array.isArray(data?.entries) ? data.entries : [];
-                  setResults(entries.filter((item) => !item?.name?.includes("-")));
-                })
-                .catch((error) => {
-                  if (error.name === "AbortError") return;
-                  setResults([]);
-                  setErrorMessage(error.message);
-                })
-                .finally(() => {
-                  setIsLoading(false);
-                });
-            }, 350);
-          }}
           onSelect={(item) => {
             setSelected(item);
           }}
@@ -261,16 +212,14 @@ export default function SearchInputDocs() {
           >
             #213
           </Link>
-          . It handles the search-box interaction pattern, while each district controls
-          the actual result source, routing, and filtering rules.
+          . It handles the search-box interaction pattern while still allowing districts
+          to customize the data source when needed.
         </Text>
         <Divider className="my-4" />
         <Text className="mt-2">
-          This keeps the library generic: districts can feed in CDA-backed results,
-          local project lists, or any other search provider without copying Lauren's
-          original Redux bundles and app-specific navigation code. Lauren's current MVP
-          implementation queries the CDA <Code>catalog/LOCATIONS</Code> endpoint for a
-          single district office.
+          By default, the component can query CDA <Code>catalog/LOCATIONS</Code> for a
+          selected office. If a district needs different behavior, passing{" "}
+          <Code>onSearch</Code> overrides that default search.
         </Text>
       </div>
 
@@ -285,34 +234,6 @@ import { useState } from "react";
 export default function DistrictHeaderSearch() {
   const [query, setQuery] = useState("");
   const [office, setOffice] = useState("SWT");
-  const [results, setResults] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-
-  async function handleSearch(nextQuery) {
-    if (nextQuery.trim().length < 3) {
-      setResults([]);
-      setErrorMessage("");
-      return;
-    }
-
-    setLoading(true);
-    setErrorMessage("");
-
-    try {
-      const response = await fetch(
-        \`https://cwms-data.usace.army.mil/cwms-data/catalog/LOCATIONS?office=\${office}&like=\${encodeURIComponent(nextQuery)}\`,
-        { headers: { Accept: "application/json" } },
-      );
-      const data = await response.json();
-      setResults(data.entries ?? []);
-    } catch (error) {
-      setResults([]);
-      setErrorMessage(error.message);
-    } finally {
-      setLoading(false);
-    }
-  }
 
   return (
     <>
@@ -323,12 +244,9 @@ export default function DistrictHeaderSearch() {
       />
       <SearchInput
         label="Search locations"
+        office={office}
         query={query}
         onQueryChange={setQuery}
-        onSearch={handleSearch}
-        results={results}
-        isLoading={loading}
-        errorMessage={errorMessage}
         minQueryLength={3}
         getResultKey={(item) => \`\${item.office}-\${item.name}\`}
         getResultLabel={(item) => item.name}
@@ -353,8 +271,8 @@ export default function DistrictHeaderSearch() {
       <Divider text="Notes" className="mt-8" />
       <ul className="list-disc pl-6 space-y-2">
         <li>
-          <Code>SearchInput</Code> does not fetch from CDA or any district API on its
-          own. It intentionally separates input behavior from data ownership.
+          If <Code>office</Code> is provided and <Code>onSearch</Code> is not, the
+          component uses the built-in CDA location search.
         </li>
         <li>
           The default renderer recognizes common fields such as <Code>name</Code>,{" "}

--- a/docs/src/pages/docs/dropdowns/search-input.jsx
+++ b/docs/src/pages/docs/dropdowns/search-input.jsx
@@ -1,0 +1,372 @@
+import { Badge, Card, Code, H3, Link, Text } from "@usace/groundwork";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Code as CodeBlock } from "../../components/code";
+import Divider from "../../components/divider";
+import ParamsTable from "../../components/params-table";
+import DocsPage from "../_docs-wrapper";
+import { OfficeDropdown, SearchInput } from "@usace-watermanagement/groundwork-water";
+
+const CDA_URL = "https://cwms-data.usace.army.mil/cwms-data";
+
+const propsList = [
+  {
+    name: "query",
+    type: "string",
+    required: false,
+    desc: "Controlled query value for the input.",
+  },
+  {
+    name: "defaultQuery",
+    type: "string",
+    required: false,
+    desc: "Initial uncontrolled query value. Default: empty string.",
+  },
+  {
+    name: "onQueryChange",
+    type: "(query: string) => void",
+    required: false,
+    desc: "Called on every keystroke with the raw input value.",
+  },
+  {
+    name: "onSearch",
+    type: "(query: string) => void",
+    required: false,
+    desc: "Debounced callback fired after debounceMs. Consumer code should fetch or filter results here.",
+  },
+  {
+    name: "results",
+    type: "T[]",
+    required: false,
+    desc: "Search results to render in the dropdown. The component does not fetch data by itself.",
+  },
+  {
+    name: "onSelect",
+    type: "(item: T) => void",
+    required: false,
+    desc: "Called when a result is selected by click or keyboard.",
+  },
+  {
+    name: "getResultKey",
+    type: "(item: T, index: number) => string | number",
+    required: false,
+    desc: "Returns a stable key for each result item.",
+  },
+  {
+    name: "getResultLabel",
+    type: "(item: T) => string",
+    required: false,
+    desc: "Controls the selected label shown in the input and the default result title.",
+  },
+  {
+    name: "getResultDescription",
+    type: "(item: T) => string | undefined",
+    required: false,
+    desc: "Optional secondary line used by the default result renderer.",
+  },
+  {
+    name: "renderResult",
+    type: "(item: T, state) => ReactNode",
+    required: false,
+    desc: "Overrides the default result layout for district-specific cards or badges.",
+  },
+  {
+    name: "minQueryLength",
+    type: "number",
+    required: false,
+    desc: "Minimum character count before results should be considered searchable. Default: 3.",
+  },
+  {
+    name: "debounceMs",
+    type: "number",
+    required: false,
+    desc: "Delay before onSearch fires. Default: 300.",
+  },
+  {
+    name: "isLoading",
+    type: "boolean",
+    required: false,
+    desc: "Shows loading skeleton rows while results are being fetched.",
+  },
+  {
+    name: "idleMessage",
+    type: "string",
+    required: false,
+    desc: "Message shown before the user has typed enough characters.",
+  },
+  {
+    name: "emptyMessage",
+    type: "string",
+    required: false,
+    desc: "Message shown when a search returns no matches.",
+  },
+  {
+    name: "errorMessage",
+    type: "string",
+    required: false,
+    desc: "Error text shown instead of the results list.",
+  },
+  {
+    name: "label / placeholder / disabled / autoFocus",
+    type: "standard input props",
+    required: false,
+    desc: "Common input behaviors forwarded to the search field.",
+  },
+  {
+    name: "className / inputClassName / listClassName",
+    type: "string",
+    required: false,
+    desc: "Classes applied to the wrapper, input, and dropdown listbox.",
+  },
+];
+
+const LiveExample = () => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [office, setOffice] = useState("SWT");
+  const timeoutRef = useRef();
+  const abortRef = useRef();
+
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const selectedLabel = useMemo(() => {
+    if (!selected) return "none";
+    return `${selected.name} (${selected.office})`;
+  }, [selected]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card className="w-full max-w-[720px]">
+        <H3>Async Search Pattern</H3>
+        <p className="mb-3 text-sm">
+          This example uses the live CDA catalog endpoint that Lauren's MVP search is
+          built on. Pick an office with data, then search for a location like{" "}
+          <Code>KEYS</Code>.
+        </p>
+        <div className="mb-4">
+          <OfficeDropdown
+            hasData
+            value={office}
+            onChange={(event) => {
+              setOffice(event.target.value);
+              setSelected(null);
+              setResults([]);
+              setErrorMessage("");
+            }}
+          />
+        </div>
+        <SearchInput
+          label={`Search ${office} locations`}
+          query={query}
+          onQueryChange={setQuery}
+          results={results}
+          isLoading={isLoading}
+          errorMessage={errorMessage}
+          minQueryLength={3}
+          onSearch={(nextQuery) => {
+            window.clearTimeout(timeoutRef.current);
+            abortRef.current?.abort();
+            if (nextQuery.trim().length < 3) {
+              setResults([]);
+              setIsLoading(false);
+              setErrorMessage("");
+              return;
+            }
+
+            setIsLoading(true);
+            setErrorMessage("");
+            timeoutRef.current = window.setTimeout(() => {
+              const controller = new AbortController();
+              abortRef.current = controller;
+              fetch(
+                `${CDA_URL}/catalog/LOCATIONS?office=${office}&like=${encodeURIComponent(nextQuery)}`,
+                {
+                  method: "GET",
+                  headers: { Accept: "application/json" },
+                  signal: controller.signal,
+                },
+              )
+                .then(async (response) => {
+                  if (!response.ok) {
+                    throw new Error(
+                      `CDA search failed: ${response.status} ${response.statusText}`,
+                    );
+                  }
+                  return response.json();
+                })
+                .then((data) => {
+                  const entries = Array.isArray(data?.entries) ? data.entries : [];
+                  setResults(entries.filter((item) => !item?.name?.includes("-")));
+                })
+                .catch((error) => {
+                  if (error.name === "AbortError") return;
+                  setResults([]);
+                  setErrorMessage(error.message);
+                })
+                .finally(() => {
+                  setIsLoading(false);
+                });
+            }, 350);
+          }}
+          onSelect={(item) => {
+            setSelected(item);
+          }}
+          getResultKey={(item) => `${item.office}-${item.name}`}
+          getResultLabel={(item) => item.name}
+          getResultDescription={(item) =>
+            `Office: ${item.office} | State: ${item.state ?? "n/a"}`
+          }
+          renderResult={(item) => (
+            <div className="flex w-full items-center justify-between gap-3">
+              <div>
+                <div className="font-medium text-slate-900">{item.name}</div>
+                <div className="mt-1 text-sm text-slate-600">
+                  Office: {item.office} | State: {item.state ?? "n/a"}
+                </div>
+              </div>
+              <Badge color={item.kind === "PROJECT" ? "blue" : "gray"}>
+                {item.kind?.toLowerCase() ?? "location"}
+              </Badge>
+            </div>
+          )}
+        />
+
+        <div className="mt-4">
+          <Code>selected:</Code>{" "}
+          <Badge color={selected ? "green" : "gray"}>{selectedLabel}</Badge>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default function SearchInputDocs() {
+  return (
+    <DocsPage middleText="SearchInput Component">
+      <div>
+        <Text>
+          <Code className="px-1 py-0.5">SearchInput</Code> provides the reusable search
+          bar requested in issue{" "}
+          <Link
+            href="https://github.com/USACE-WaterManagement/groundwork-water/issues/213"
+            className="underline"
+          >
+            #213
+          </Link>
+          . It handles the search-box interaction pattern, while each district controls
+          the actual result source, routing, and filtering rules.
+        </Text>
+        <Divider className="my-4" />
+        <Text className="mt-2">
+          This keeps the library generic: districts can feed in CDA-backed results,
+          local project lists, or any other search provider without copying Lauren's
+          original Redux bundles and app-specific navigation code. Lauren's current MVP
+          implementation queries the CDA <Code>catalog/LOCATIONS</Code> endpoint for a
+          single district office.
+        </Text>
+      </div>
+
+      <Divider text="Live Example" className="mt-8" />
+      <LiveExample />
+
+      <Divider text="Example Usage" className="mt-8" />
+      <CodeBlock language="jsx">
+        {`import { OfficeDropdown, SearchInput } from "@usace-watermanagement/groundwork-water";
+import { useState } from "react";
+
+export default function DistrictHeaderSearch() {
+  const [query, setQuery] = useState("");
+  const [office, setOffice] = useState("SWT");
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  async function handleSearch(nextQuery) {
+    if (nextQuery.trim().length < 3) {
+      setResults([]);
+      setErrorMessage("");
+      return;
+    }
+
+    setLoading(true);
+    setErrorMessage("");
+
+    try {
+      const response = await fetch(
+        \`https://cwms-data.usace.army.mil/cwms-data/catalog/LOCATIONS?office=\${office}&like=\${encodeURIComponent(nextQuery)}\`,
+        { headers: { Accept: "application/json" } },
+      );
+      const data = await response.json();
+      setResults(data.entries ?? []);
+    } catch (error) {
+      setResults([]);
+      setErrorMessage(error.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <OfficeDropdown
+        hasData
+        value={office}
+        onChange={(event) => setOffice(event.target.value)}
+      />
+      <SearchInput
+        label="Search locations"
+        query={query}
+        onQueryChange={setQuery}
+        onSearch={handleSearch}
+        results={results}
+        isLoading={loading}
+        errorMessage={errorMessage}
+        minQueryLength={3}
+        getResultKey={(item) => \`\${item.office}-\${item.name}\`}
+        getResultLabel={(item) => item.name}
+        getResultDescription={(item) => \`Office: \${item.office} | State: \${item.state ?? "n/a"}\`}
+        onSelect={(item) => {
+          window.location.assign(item.kind === "PROJECT"
+            ? \`/location/\${item.name}\`
+            : \`/gage-location/\${item.name}\`);
+        }}
+      />
+    </>
+  );
+}`}
+      </CodeBlock>
+
+      <Divider text="API Reference" className="mt-8" />
+      <div className="font-bold text-lg pt-6">
+        Component Props - <Code className="p-2">{"<SearchInput {...} />"}</Code>
+      </div>
+      <ParamsTable paramsList={propsList} />
+
+      <Divider text="Notes" className="mt-8" />
+      <ul className="list-disc pl-6 space-y-2">
+        <li>
+          <Code>SearchInput</Code> does not fetch from CDA or any district API on its
+          own. It intentionally separates input behavior from data ownership.
+        </li>
+        <li>
+          The default renderer recognizes common fields such as <Code>name</Code>,{" "}
+          <Code>label</Code>, <Code>publicName</Code>, <Code>office</Code>,{" "}
+          <Code>state</Code>, and <Code>kind</Code>, but districts can fully override
+          rendering with <Code>renderResult</Code>.
+        </li>
+        <li>
+          Keyboard support is built in for arrow navigation, Enter to select, and Escape
+          to dismiss the list.
+        </li>
+      </ul>
+    </DocsPage>
+  );
+}

--- a/docs/src/pages/docs/dropdowns/search-input.jsx
+++ b/docs/src/pages/docs/dropdowns/search-input.jsx
@@ -252,9 +252,10 @@ export default function DistrictHeaderSearch() {
         getResultLabel={(item) => item.name}
         getResultDescription={(item) => \`Office: \${item.office} | State: \${item.state ?? "n/a"}\`}
         onSelect={(item) => {
+          // NOTE: You should use your district's routing solution here. This is just an example of how to access item properties.
           window.location.assign(item.kind === "PROJECT"
-            ? \`/location/\${item.name}\`
-            : \`/gage-location/\${item.name}\`);
+            ? \`/project/\${item.name}\`
+            : \`/gage/\${item.name}\`);
         }}
       />
     </>

--- a/lib/components/data/search/SearchInput.tsx
+++ b/lib/components/data/search/SearchInput.tsx
@@ -1,0 +1,390 @@
+import { gwMerge, Badge, Skeleton } from "@usace/groundwork";
+import {
+  KeyboardEvent,
+  ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  HiMagnifyingGlass,
+  HiOutlineBuildingOffice2,
+  HiOutlineMapPin,
+} from "react-icons/hi2";
+
+import useDebounce from "../utilities/useDebounce";
+
+type SearchInputRenderState = {
+  isActive: boolean;
+  query: string;
+};
+
+type SearchInputProps<T> = {
+  query?: string;
+  defaultQuery?: string;
+  onQueryChange?: (query: string) => void;
+  onSearch?: (query: string) => void;
+  onSelect?: (item: T) => void;
+  results?: T[];
+  getResultKey?: (item: T, index: number) => string | number;
+  getResultLabel?: (item: T) => string;
+  getResultDescription?: (item: T) => string | undefined;
+  renderResult?: (item: T, state: SearchInputRenderState) => ReactNode;
+  label?: string;
+  placeholder?: string;
+  minQueryLength?: number;
+  debounceMs?: number;
+  idleMessage?: string;
+  emptyMessage?: string;
+  errorMessage?: string;
+  isLoading?: boolean;
+  disabled?: boolean;
+  className?: string;
+  inputClassName?: string;
+  listClassName?: string;
+  autoFocus?: boolean;
+};
+
+type SearchResultRecord = Record<string, unknown>;
+
+const getStringValue = (value: unknown) => (typeof value === "string" ? value : "");
+
+const defaultGetResultLabel = <T,>(item: T) => {
+  const record = item as SearchResultRecord;
+  return (
+    getStringValue(record.label) ||
+    getStringValue(record["public-name"]) ||
+    getStringValue(record.publicName) ||
+    getStringValue(record.title) ||
+    getStringValue(record.name) ||
+    getStringValue(record.id)
+  );
+};
+
+const defaultGetResultDescription = <T,>(item: T) => {
+  const record = item as SearchResultRecord;
+  const office = getStringValue(record.office);
+  const state = getStringValue(record.state);
+  const parts = [office && `Office: ${office}`, state && `State: ${state}`].filter(
+    Boolean,
+  );
+  return parts.join(" | ") || undefined;
+};
+
+const getKindLabel = (value: unknown) => getStringValue(value).toLowerCase();
+
+const DefaultResultIcon = ({ item }: { item: SearchResultRecord }) => {
+  const kind = getKindLabel(item.kind ?? item.type);
+  if (kind.includes("project")) {
+    return <HiOutlineBuildingOffice2 className="gww-h-5 gww-w-5 gww-text-blue-700" />;
+  }
+
+  return <HiOutlineMapPin className="gww-h-5 gww-w-5 gww-text-slate-500" />;
+};
+
+const DefaultResult = <T,>({
+  item,
+  getResultLabel,
+  getResultDescription,
+}: {
+  item: T;
+  getResultLabel: (item: T) => string;
+  getResultDescription: (item: T) => string | undefined;
+}) => {
+  const record = item as SearchResultRecord;
+  const description = getResultDescription(item);
+  const kind = getStringValue(record.kind ?? record.type);
+
+  return (
+    <div className="gww-flex gww-items-start gww-gap-3">
+      <div className="gww-mt-0.5 gww-flex-none">
+        <DefaultResultIcon item={record} />
+      </div>
+      <div className="gww-min-w-0 gww-flex-1">
+        <div className="gww-flex gww-items-center gww-gap-2">
+          <span className="gww-truncate gww-font-medium gww-text-slate-900">
+            {getResultLabel(item)}
+          </span>
+          {kind ? (
+            <Badge color="gray" className="gww-whitespace-nowrap">
+              {kind}
+            </Badge>
+          ) : null}
+        </div>
+        {description ? (
+          <div className="gww-mt-1 gww-text-sm gww-text-slate-600">{description}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+const SearchInput = <T,>({
+  query,
+  defaultQuery = "",
+  onQueryChange,
+  onSearch,
+  onSelect,
+  results = [],
+  getResultKey,
+  getResultLabel = defaultGetResultLabel,
+  getResultDescription = defaultGetResultDescription,
+  renderResult,
+  label,
+  placeholder = "Search",
+  minQueryLength = 3,
+  debounceMs = 300,
+  idleMessage = "Type more to search.",
+  emptyMessage = "No matching results.",
+  errorMessage,
+  isLoading = false,
+  disabled = false,
+  className,
+  inputClassName,
+  listClassName,
+  autoFocus = false,
+}: SearchInputProps<T>) => {
+  const [internalQuery, setInternalQuery] = useState(defaultQuery);
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const onSearchRef = useRef<SearchInputProps<T>["onSearch"]>(onSearch);
+  const listboxId = useId();
+  const isControlled = query !== undefined;
+  const currentQuery = (isControlled ? query : internalQuery) ?? "";
+  const normalizedQuery = currentQuery.trim();
+  const debouncedQuery = useDebounce(normalizedQuery, debounceMs);
+  const canSearch = debouncedQuery.length >= minQueryLength;
+  const showPanel = isOpen && !disabled;
+  const hasResults = results.length > 0;
+  const remainingCharacters = Math.max(minQueryLength - normalizedQuery.length, 0);
+  const computedIdleMessage =
+    idleMessage === "Type more to search."
+      ? `Type ${remainingCharacters} more character${remainingCharacters === 1 ? "" : "s"} to search.`
+      : idleMessage;
+
+  useEffect(() => {
+    // Keep the latest callback without making the debounced search effect
+    // rerun on every parent re-render.
+    onSearchRef.current = onSearch;
+  }, [onSearch]);
+
+  useEffect(() => {
+    onSearchRef.current?.(debouncedQuery);
+  }, [debouncedQuery]);
+
+  useEffect(() => {
+    // Close the popover when focus leaves the component via pointer interaction.
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+        setActiveIndex(-1);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  useEffect(() => {
+    // Clamp the highlighted row as results appear/disappear so keyboard
+    // navigation does not point at a stale index.
+    if (!showPanel || !hasResults) {
+      setActiveIndex(-1);
+      return;
+    }
+
+    setActiveIndex((index) => {
+      if (index >= results.length) return results.length - 1;
+      return index;
+    });
+  }, [hasResults, results.length, showPanel]);
+
+  const activeDescendant = useMemo(() => {
+    if (activeIndex < 0 || activeIndex >= results.length) return undefined;
+    return `${listboxId}-option-${activeIndex}`;
+  }, [activeIndex, listboxId, results.length]);
+
+  const setQueryValue = (nextQuery: string) => {
+    if (!isControlled) {
+      setInternalQuery(nextQuery);
+    }
+    onQueryChange?.(nextQuery);
+  };
+
+  const handleSelect = (item: T) => {
+    // Mirror combobox behavior by writing the chosen label back into the input.
+    setIsOpen(false);
+    setActiveIndex(-1);
+    setQueryValue(getResultLabel(item));
+    onSelect?.(item);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // Support the standard combobox keys: arrows to move, Enter to choose,
+    // Escape to dismiss.
+    if (!showPanel || !hasResults) {
+      if (event.key === "ArrowDown" && normalizedQuery.length >= minQueryLength) {
+        setIsOpen(true);
+      }
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1 >= results.length ? 0 : index + 1));
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) => (index <= 0 ? results.length - 1 : index - 1));
+      return;
+    }
+
+    if (event.key === "Enter" && activeIndex >= 0) {
+      event.preventDefault();
+      handleSelect(results[activeIndex]);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      setIsOpen(false);
+      setActiveIndex(-1);
+    }
+  };
+
+  const statusContent = (() => {
+    if (errorMessage) {
+      return (
+        <div className="gww-px-4 gww-py-3 gww-text-sm gww-text-red-700">
+          {errorMessage}
+        </div>
+      );
+    }
+
+    if (!canSearch) {
+      return (
+        <div className="gww-px-4 gww-py-3 gww-text-sm gww-text-slate-500">
+          {computedIdleMessage}
+        </div>
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <div className="gww-space-y-2 gww-p-4">
+          <Skeleton className="gww-h-4 gww-w-full" />
+          <Skeleton className="gww-h-4 gww-w-4/5" />
+        </div>
+      );
+    }
+
+    if (!hasResults) {
+      return (
+        <div className="gww-px-4 gww-py-3 gww-text-sm gww-text-slate-500">
+          {emptyMessage}
+        </div>
+      );
+    }
+
+    return null;
+  })();
+
+  return (
+    <div ref={containerRef} className={gwMerge("gww-relative gww-w-full", className)}>
+      {label ? (
+        <label className="gww-mb-1 gww-block gww-text-sm gww-font-medium gww-text-slate-700">
+          {label}
+        </label>
+      ) : null}
+      <div className="gww-relative">
+        <div className="gww-pointer-events-none gww-absolute gww-inset-y-0 gww-left-0 gww-flex gww-items-center gww-pl-3">
+          <HiMagnifyingGlass
+            className="gww-h-5 gww-w-5 gww-text-slate-400"
+            aria-hidden="true"
+          />
+        </div>
+        <input
+          type="text"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-expanded={showPanel}
+          aria-activedescendant={activeDescendant}
+          autoFocus={autoFocus}
+          disabled={disabled}
+          value={currentQuery}
+          placeholder={placeholder}
+          className={gwMerge(
+            "gww-block gww-w-full gww-rounded-md gww-border gww-border-slate-300 gww-bg-white gww-py-2.5 gww-pl-10 gww-pr-3 gww-text-slate-900 placeholder:gww-text-slate-400 focus:gww-border-blue-600 focus:gww-outline-none focus:gww-ring-2 focus:gww-ring-blue-200 disabled:gww-cursor-not-allowed disabled:gww-bg-slate-100",
+            inputClassName,
+          )}
+          onFocus={() => {
+            if (normalizedQuery.length > 0 || hasResults || errorMessage) {
+              setIsOpen(true);
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          onChange={(event) => {
+            setQueryValue(event.target.value);
+            setIsOpen(true);
+            setActiveIndex(-1);
+          }}
+        />
+      </div>
+
+      {showPanel ? (
+        <div
+          id={listboxId}
+          role="listbox"
+          className={gwMerge(
+            "gww-absolute gww-z-20 gww-mt-1 gww-max-h-96 gww-w-full gww-overflow-auto gww-rounded-md gww-border gww-border-slate-200 gww-bg-white gww-shadow-lg",
+            listClassName,
+          )}
+        >
+          {statusContent}
+          {canSearch && !isLoading && !errorMessage && hasResults
+            ? results.map((item, index) => {
+                const itemKey =
+                  getResultKey?.(item, index) ?? `${getResultLabel(item)}-${index}`;
+                const isActive = index === activeIndex;
+
+                return (
+                  <button
+                    id={`${listboxId}-option-${index}`}
+                    key={itemKey}
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    className={gwMerge(
+                      "gww-flex gww-w-full gww-items-start gww-border-t gww-border-slate-100 gww-px-4 gww-py-3 gww-text-left first:gww-border-t-0",
+                      isActive ? "gww-bg-blue-50" : "hover:gww-bg-slate-50",
+                    )}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => handleSelect(item)}
+                  >
+                    {renderResult ? (
+                      renderResult(item, { isActive, query: currentQuery })
+                    ) : (
+                      <DefaultResult
+                        item={item}
+                        getResultLabel={getResultLabel}
+                        getResultDescription={getResultDescription}
+                      />
+                    )}
+                  </button>
+                );
+              })
+            : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export { SearchInput };
+export type { SearchInputProps };
+export default SearchInput;

--- a/lib/components/data/search/SearchInput.tsx
+++ b/lib/components/data/search/SearchInput.tsx
@@ -24,6 +24,8 @@ type SearchInputRenderState = {
 type SearchInputProps<T> = {
   query?: string;
   defaultQuery?: string;
+  office?: string;
+  cdaUrl?: string;
   onQueryChange?: (query: string) => void;
   onSearch?: (query: string) => void;
   onSelect?: (item: T) => void;
@@ -124,10 +126,12 @@ const DefaultResult = <T,>({
 const SearchInput = <T,>({
   query,
   defaultQuery = "",
+  office,
+  cdaUrl = "https://cwms-data.usace.army.mil/cwms-data",
   onQueryChange,
   onSearch,
   onSelect,
-  results = [],
+  results,
   getResultKey,
   getResultLabel = defaultGetResultLabel,
   getResultDescription = defaultGetResultDescription,
@@ -147,18 +151,25 @@ const SearchInput = <T,>({
   autoFocus = false,
 }: SearchInputProps<T>) => {
   const [internalQuery, setInternalQuery] = useState(defaultQuery);
+  const [internalResults, setInternalResults] = useState<T[]>([]);
+  const [internalIsLoading, setInternalIsLoading] = useState(false);
+  const [internalErrorMessage, setInternalErrorMessage] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const onSearchRef = useRef<SearchInputProps<T>["onSearch"]>(onSearch);
+  const searchAbortRef = useRef<AbortController | null>(null);
   const listboxId = useId();
   const isControlled = query !== undefined;
   const currentQuery = (isControlled ? query : internalQuery) ?? "";
   const normalizedQuery = currentQuery.trim();
   const debouncedQuery = useDebounce(normalizedQuery, debounceMs);
   const canSearch = debouncedQuery.length >= minQueryLength;
+  const effectiveResults = results ?? internalResults;
+  const effectiveIsLoading = isLoading || internalIsLoading;
+  const effectiveErrorMessage = errorMessage ?? internalErrorMessage;
   const showPanel = isOpen && !disabled;
-  const hasResults = results.length > 0;
+  const hasResults = effectiveResults.length > 0;
   const remainingCharacters = Math.max(minQueryLength - normalizedQuery.length, 0);
   const computedIdleMessage =
     idleMessage === "Type more to search."
@@ -172,8 +183,60 @@ const SearchInput = <T,>({
   }, [onSearch]);
 
   useEffect(() => {
-    onSearchRef.current?.(debouncedQuery);
-  }, [debouncedQuery]);
+    if (onSearchRef.current) {
+      onSearchRef.current(debouncedQuery);
+      return;
+    }
+
+    searchAbortRef.current?.abort();
+
+    if (!office || debouncedQuery.length < minQueryLength) {
+      setInternalResults([]);
+      setInternalIsLoading(false);
+      setInternalErrorMessage("");
+      return;
+    }
+
+    const controller = new AbortController();
+    searchAbortRef.current = controller;
+    setInternalIsLoading(true);
+    setInternalErrorMessage("");
+
+    fetch(
+      `${cdaUrl}/catalog/LOCATIONS?office=${office}&like=${encodeURIComponent(debouncedQuery)}`,
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      },
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(
+            `CDA search failed: ${response.status} ${response.statusText}`,
+          );
+        }
+        return response.json();
+      })
+      .then((data) => {
+        const entries = Array.isArray(data?.entries)
+          ? (data.entries as Array<{ name?: string }>)
+          : [];
+        setInternalResults(entries.filter((item) => !item.name?.includes("-")) as T[]);
+      })
+      .catch((fetchError: Error & { name?: string }) => {
+        if (fetchError.name === "AbortError") return;
+        setInternalResults([]);
+        setInternalErrorMessage(fetchError.message);
+      })
+      .then(() => {
+        if (!controller.signal.aborted) {
+          setInternalIsLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [cdaUrl, debouncedQuery, minQueryLength, office]);
 
   useEffect(() => {
     // Close the popover when focus leaves the component via pointer interaction.
@@ -185,7 +248,10 @@ const SearchInput = <T,>({
     };
 
     document.addEventListener("mousedown", handlePointerDown);
-    return () => document.removeEventListener("mousedown", handlePointerDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      searchAbortRef.current?.abort();
+    };
   }, []);
 
   useEffect(() => {
@@ -197,15 +263,15 @@ const SearchInput = <T,>({
     }
 
     setActiveIndex((index) => {
-      if (index >= results.length) return results.length - 1;
+      if (index >= effectiveResults.length) return effectiveResults.length - 1;
       return index;
     });
-  }, [hasResults, results.length, showPanel]);
+  }, [effectiveResults.length, hasResults, showPanel]);
 
   const activeDescendant = useMemo(() => {
-    if (activeIndex < 0 || activeIndex >= results.length) return undefined;
+    if (activeIndex < 0 || activeIndex >= effectiveResults.length) return undefined;
     return `${listboxId}-option-${activeIndex}`;
-  }, [activeIndex, listboxId, results.length]);
+  }, [activeIndex, effectiveResults.length, listboxId]);
 
   const setQueryValue = (nextQuery: string) => {
     if (!isControlled) {
@@ -234,19 +300,19 @@ const SearchInput = <T,>({
 
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setActiveIndex((index) => (index + 1 >= results.length ? 0 : index + 1));
+      setActiveIndex((index) => (index + 1 >= effectiveResults.length ? 0 : index + 1));
       return;
     }
 
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      setActiveIndex((index) => (index <= 0 ? results.length - 1 : index - 1));
+      setActiveIndex((index) => (index <= 0 ? effectiveResults.length - 1 : index - 1));
       return;
     }
 
     if (event.key === "Enter" && activeIndex >= 0) {
       event.preventDefault();
-      handleSelect(results[activeIndex]);
+      handleSelect(effectiveResults[activeIndex]);
       return;
     }
 
@@ -257,10 +323,10 @@ const SearchInput = <T,>({
   };
 
   const statusContent = (() => {
-    if (errorMessage) {
+    if (effectiveErrorMessage) {
       return (
         <div className="gww-px-4 gww-py-3 gww-text-sm gww-text-red-700">
-          {errorMessage}
+          {effectiveErrorMessage}
         </div>
       );
     }
@@ -273,7 +339,7 @@ const SearchInput = <T,>({
       );
     }
 
-    if (isLoading) {
+    if (effectiveIsLoading) {
       return (
         <div className="gww-space-y-2 gww-p-4">
           <Skeleton className="gww-h-4 gww-w-full" />
@@ -323,7 +389,7 @@ const SearchInput = <T,>({
             inputClassName,
           )}
           onFocus={() => {
-            if (normalizedQuery.length > 0 || hasResults || errorMessage) {
+            if (normalizedQuery.length > 0 || hasResults || effectiveErrorMessage) {
               setIsOpen(true);
             }
           }}
@@ -346,8 +412,8 @@ const SearchInput = <T,>({
           )}
         >
           {statusContent}
-          {canSearch && !isLoading && !errorMessage && hasResults
-            ? results.map((item, index) => {
+          {canSearch && !effectiveIsLoading && !effectiveErrorMessage && hasResults
+            ? effectiveResults.map((item, index) => {
                 const itemKey =
                   getResultKey?.(item, index) ?? `${getResultLabel(item)}-${index}`;
                 const isActive = index === activeIndex;

--- a/lib/components/data/search/SearchInput.tsx
+++ b/lib/components/data/search/SearchInput.tsx
@@ -362,12 +362,12 @@ const SearchInput = <T,>({
   return (
     <div ref={containerRef} className={gwMerge("gww-relative gww-w-full", className)}>
       {label ? (
-        <label className="gww-mb-1 gww-block gww-text-sm gww-font-medium gww-text-slate-700">
+        <label className="gww-mb-1 gww-block gww-text-sm gww-font-medium gww-left-5 gww-text-slate-700">
           {label}
         </label>
       ) : null}
-      <div className="gww-relative">
-        <div className="gww-pointer-events-none gww-absolute gww-inset-y-0 gww-left-0 gww-flex gww-items-center gww-pl-3">
+      <div className="gww-flex gww-flex-row gww-items-center">
+        <div className="gww-pointer-events-none gww-flex gww-items-center gww-pr-3">
           <HiMagnifyingGlass
             className="gww-h-5 gww-w-5 gww-text-slate-400"
             aria-hidden="true"
@@ -385,7 +385,7 @@ const SearchInput = <T,>({
           value={currentQuery}
           placeholder={placeholder}
           className={gwMerge(
-            "gww-block gww-w-full gww-rounded-md gww-border gww-border-slate-300 gww-bg-white gww-py-2.5 gww-pl-10 gww-pr-3 gww-text-slate-900 placeholder:gww-text-slate-400 focus:gww-border-blue-600 focus:gww-outline-none focus:gww-ring-2 focus:gww-ring-blue-200 disabled:gww-cursor-not-allowed disabled:gww-bg-slate-100",
+            "gww-w-full gww-rounded-md gww-border gww-border-slate-300 gww-pr-3 gww-bg-white gww-flex gww-text-slate-900 placeholder:gww-text-slate-400 focus:gww-border-blue-600 focus:gww-outline-none focus:gww-ring-2 focus:gww-ring-blue-200 disabled:gww-cursor-not-allowed disabled:gww-bg-slate-100",
             inputClassName,
           )}
           onFocus={() => {

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -69,6 +69,7 @@ import { createKeycloakAuthMethod } from "./components/data/utilities/auth/keycl
 
 // dropdowns
 import { OfficeDropdown } from "./components/data/dropdowns/OfficeDropdown";
+import SearchInput from "./components/data/search/SearchInput";
 
 // import { helperFunction } from './utils/helpers';
 
@@ -80,6 +81,7 @@ export {
   CdaLatestValueCard,
   CdaUrlProvider,
   OfficeDropdown,
+  SearchInput,
   useCdaBlob,
   useCdaBlobs,
   useCdaCatalog,


### PR DESCRIPTION

  ## Summary                                                                               
                                                                                           
  Adds a reusable SearchInput component to groundwork-water so district sites can share the
  same search bar behavior without copying app-specific Redux/search code.                 
                                                                                           
  ## What changed                                                                          
                                                                                           
  - added SearchInput to the library export                                                
  - built in debounced query handling, dropdown results, keyboard nav, and loading/empty/  
    error states                                                                           
  - made result rendering customizable while keeping a sensible default layout             
  - added docs and a live example using OfficeDropdown with hasData                        
  - wired the docs example to the CDA catalog/LOCATIONS endpoint, matching @LaurenAllin current
    search approach                                                                        
                                                                                           
  ## Notes                                                                                 
                                                                                           
  - Takes an office and provides catalog entries, onSelect to override                                                            
