### PR TITLE
Add missing keycloakHost.ts import

### DIFF
--- a/.changeset/smart-goats-exist.md
+++ b/.changeset/smart-goats-exist.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": patch
+---
+
+Correct missing import for keycloakhost

--- a/lib/components/data/utilities/auth/keycloakHost.ts
+++ b/lib/components/data/utilities/auth/keycloakHost.ts
@@ -1,0 +1,12 @@
+const KEYCLOAK_REALMS_SEGMENT = "/realms/";
+
+export const normalizeKeycloakHost = (host: string) => {
+  const trimmedHost = host.trim().replace(/\/$/, "");
+  const realmsIndex = trimmedHost.indexOf(KEYCLOAK_REALMS_SEGMENT);
+
+  if (realmsIndex >= 0) {
+    return trimmedHost.slice(0, realmsIndex);
+  }
+
+  return trimmedHost;
+};

--- a/lib/components/data/utilities/auth/keycloakOidcClient.ts
+++ b/lib/components/data/utilities/auth/keycloakOidcClient.ts
@@ -1,4 +1,5 @@
 import { UserManager, UserManagerSettings, WebStorageStateStore } from "oidc-client-ts";
+import { normalizeKeycloakHost } from "./keycloakHost";
 
 export interface KeycloakPkceConfig {
   host: string;
@@ -36,7 +37,7 @@ export const createKeycloakOidcClient = ({
     throw new Error("Keycloak PKCE auth requires a redirect URI");
   }
 
-  const normalizedHost = host.trim().replace(/\/$/, "");
+  const normalizedHost = normalizeKeycloakHost(host);
 
   const settings: UserManagerSettings = {
     authority: `${normalizedHost}/realms/${realm}`,


### PR DESCRIPTION
Add missing import

I had forgot to commit this utility script for trimming and removing trailing slash of the keycloak host URL

It's used for the dynamic realm imports from the CDA config

It was in `keycloakAuthMethod` preventing a local build

Confirmed build and ran locally to ensure still loading. 

#142 would add build requirement to PR and prevent this from happening! (Me forgetting a final build before pushing)