### PR TITLE
Fix Groundwork 4 peer dependency support

### DIFF
--- a/.changeset/fix-groundwork-4-peer.md
+++ b/.changeset/fix-groundwork-4-peer.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": patch
+---
+
+Allow downstream applications to install Groundwork Water alongside Groundwork 4.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@usace-watermanagement/groundwork-water",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@usace-watermanagement/groundwork-water",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "cwmsjs": "^2.3.0-2024.12.10",
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "@tanstack/react-query": "^5.51.23",
-        "@usace/groundwork": "^3.14.19",
+        "@usace/groundwork": "^3.14.19 || ^4.0.0",
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.51.23",
-    "@usace/groundwork": "^3.14.19",
+    "@usace/groundwork": "^3.14.19 || ^4.0.0",
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0"
   }


### PR DESCRIPTION
## Summary

Fixes the Groundwork Water peer dependency metadata so downstream apps can install GWW with `@usace/groundwork@4.x`.

## Root Cause

`@usace-watermanagement/groundwork-water@3.9.0` declared `@usace/groundwork` as `^3.14.19` only. Downstream apps updating to Groundwork 4 hit npm peer dependency resolution failures before their build could run.

## Changes

- Widen `@usace/groundwork` peer dependency support to `^3.14.19 || ^4.0.0`
- Sync root package lock metadata
- Add a patch changeset so the corrected peer range is published

Closes #250

## Validation

- `npm.cmd test`
- `npm.cmd run build-lib`
- Temp downstream install with local packed GWW, `@usace/groundwork@4.1.0`, React 18, React DOM 18, and React Query