### PR TITLE
update auth documentation

### DIFF
--- a/.changeset/slick-pots-show.md
+++ b/.changeset/slick-pots-show.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+update auth documentation

--- a/docs/src/pages/docs/auth/auth-provider.jsx
+++ b/docs/src/pages/docs/auth/auth-provider.jsx
@@ -58,13 +58,35 @@ function AuthProviderDocs() {
         {`import { AuthProvider } from "@usace-watermanagement/groundwork-water";`}
       </CodeBlock>
       <Text className="mb-4">Create an appropriate {authMethod}.</Text>
-      <Text>Wrap your application with an {authProvider}:</Text>
+      <Text>
+        Wrap your application with an {authProvider}. To enable user profile retrieval
+        via <Code>useAuth().profile</Code>, provide a CDA URL either through a{" "}
+        <Code>CdaUrlProvider</Code> wrapper or the <Code>cdaUrl</Code> prop:
+      </Text>
       <CodeBlock language="jsx">
-        {`<React.StrictMode>
+        {`import {
+  AuthProvider,
+  CdaUrlProvider,
+  createKeycloakAuthMethod,
+} from "@usace-watermanagement/groundwork-water";
+
+const authMethod = createKeycloakAuthMethod({
+  host: "https://identity-test.cwbi.mil/auth",
+  realm: "cwbi",
+  client: "cwms",
+  flow: "authorization-code-pkce",
+  redirectUri: window.location.href,
+  postLogoutRedirectUri: window.location.href,
+  providerHint: "federation-eams",
+});
+
+<React.StrictMode>
   <QueryClientProvider client={queryClient}>
-    <AuthProvider method={authMethod}>
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <CdaUrlProvider url={cdaUrl}>
+      <AuthProvider method={authMethod}>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </CdaUrlProvider>
   </QueryClientProvider>
 </React.StrictMode>
 `}

--- a/docs/src/pages/docs/auth/index.jsx
+++ b/docs/src/pages/docs/auth/index.jsx
@@ -119,6 +119,22 @@ function AuthenticationDocs() {
         the {authProvider}. Typically, this can be done at the top level of your
         application, e.g. App.jsx/tsx, using the provided constructor functions.
       </Text>
+      <Text className="mt-2 font-semibold">Keycloak (PKCE - recommended):</Text>
+      <CodeBlock language="jsx">
+        {`import { createKeycloakAuthMethod } from "@usace-watermanagement/groundwork-water";
+
+const authMethod = createKeycloakAuthMethod({
+  host: "https://identity-test.cwbi.mil/auth",
+  realm: "cwbi",
+  client: "cwms",
+  flow: "authorization-code-pkce",
+  redirectUri: window.location.href,
+  postLogoutRedirectUri: window.location.href,
+  providerHint: "federation-eams",
+});
+`}
+      </CodeBlock>
+      <Text className="mt-2 font-semibold">CWMSLogin:</Text>
       <CodeBlock language="jsx">
         {`import { createCwmsLoginAuthMethod } from "@usace-watermanagement/groundwork-water";
 
@@ -133,21 +149,25 @@ const authMethod = createCwmsLoginAuthMethod({
         Your application (or the parts of your application requiring authentication)
         must be wrapped in an {authProvider} component. The previously-created{" "}
         {authMethod} will be passed to the {authProvider} to apply the configuration
-        within your application.
+        within your application. Wrap with a <Code>CdaUrlProvider</Code> to enable
+        automatic user profile retrieval via <Code>useAuth().profile</Code>.
       </Text>
       <CodeBlock language="jsx">
         {`import {
   AuthProvider,
-  createCwmsLoginAuthMethod,
+  CdaUrlProvider,
+  createKeycloakAuthMethod,
 } from "@usace-watermanagement/groundwork-water";
 
 // queryClient setup, authMethod setup, etc...
-        
+
 <React.StrictMode>
   <QueryClientProvider client={queryClient}>
-    <AuthProvider method={authMethod}>
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <CdaUrlProvider url={cdaUrl}>
+      <AuthProvider method={authMethod}>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </CdaUrlProvider>
   </QueryClientProvider>
 </React.StrictMode>
 `}

--- a/docs/src/pages/docs/auth/keycloak.jsx
+++ b/docs/src/pages/docs/auth/keycloak.jsx
@@ -29,8 +29,8 @@ const componentProps = [
   {
     name: "flow",
     type: "string",
-    default: "undefined",
-    desc: "The authentication flow to use. Use 'authorization-code-pkce' for the redirect-based OIDC flow, or 'direct-grant' for the legacy password grant flow.",
+    default: '"authorization-code-pkce"',
+    desc: "The authentication flow to use. Use 'authorization-code-pkce' for the redirect-based OIDC flow (recommended), or 'direct-grant' for the legacy password grant flow.",
   },
   {
     name: "redirectUri",
@@ -99,8 +99,8 @@ function KeycloakDocs() {
         <Text className="mt-4">
           Use the exact Keycloak base path that serves your realm endpoints. For the
           CWBI test environment used by <Code>cwms-cli</Code>, that is
-          <Code> https://identity-test.cwbi.us/auth</Code> rather than the stripped root
-          URL.
+          <Code> https://identity-test.cwbi.mil/auth</Code> rather than the stripped
+          root URL.
         </Text>
         <Text className="mt-4">
           This authentication method uses refresh tokens and will automatically manage
@@ -128,7 +128,7 @@ function KeycloakDocs() {
       <Divider text="Example Usage" className="mt-6 mb-4" />
       <CodeBlock language="jsx">
         {`import { createKeycloakAuthMethod } from "@usace-watermanagement/groundwork-water";
-      
+
 // Set authHost from environment variables
 
 const authMethod = createKeycloakAuthMethod({
@@ -136,7 +136,8 @@ const authMethod = createKeycloakAuthMethod({
   realm: "cwbi",
   client: "cwms",
   flow: "authorization-code-pkce",
-  redirectUri: window.location.origin,
+  redirectUri: window.location.href,
+  postLogoutRedirectUri: window.location.href,
   providerHint: "federation-eams",
 });`}
       </CodeBlock>


### PR DESCRIPTION
Updated auth docs to recommend Keycloak PKCE flow, added CdaUrlProvider usage examples for profile retrieval, and corrected the Keycloak host URL to identity-test.cwbi.mil.