### PR TITLE
Fix CWMS Spreadsheet toolbar button behavior

### DIFF
--- a/.changeset/eighty-papers-show.md
+++ b/.changeset/eighty-papers-show.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Prevent CWMSSpreadsheet toolbar buttons from submitting forms and add options to hide each button.

--- a/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
+++ b/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
@@ -126,6 +126,18 @@ const componentProps = [
     default: "false",
     desc: "When true, rows and columns are visually swapped. Column definitions become visual rows and data rows become visual columns. Keyboard navigation, selection, copy/paste all follow the transposed layout.",
   },
+  {
+    name: "showCopyAllDataButton",
+    type: "boolean",
+    default: "true",
+    desc: "Whether to show the Copy All Data button.",
+  },
+  {
+    name: "showSelectAllButton",
+    type: "boolean",
+    default: "true",
+    desc: "Whether to show the Select All button.",
+  },
 ];
 
 function CWMSSpreadsheetDocs() {
@@ -546,6 +558,56 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
   ]}
   rows={5}
   transpose={true}
+  defaultData={[
+    ["650.2", "1250", "72.5"],
+    ["650.3", "1275", "72.3"],
+    ["650.3", "1265", "72.4"],
+    ["650.4", "1280", "72.6"],
+    ["", "", ""],
+  ]}
+/>`}
+      </CodeBlock>
+
+      <Divider text="Button Visibility" className="mt-8" />
+      <Text className="mb-4">
+        Set <Code>showCopyAllDataButton={"{false}"}</Code> or{" "}
+        <Code>showSelectAllButton={"{false}"}</Code> to hide either spreadsheet toolbar
+        button. Both buttons are shown by default.
+      </Text>
+
+      <div className="overflow-x-auto">
+        <CWMSForm office="SWT">
+          <CWMSSpreadsheet
+            columns={[
+              { key: "stage", label: "Stage (ft)", type: "number" },
+              { key: "flow", label: "Flow (cfs)", type: "number" },
+              { key: "temp", label: "Temp (°F)", type: "number" },
+            ]}
+            rows={5}
+            showCopyAllDataButton={false}
+            showSelectAllButton={false}
+            defaultData={[
+              ["650.2", "1250", "72.5"],
+              ["650.3", "1275", "72.3"],
+              ["650.3", "1265", "72.4"],
+              ["650.4", "1280", "72.6"],
+              ["", "", ""],
+            ]}
+          />
+        </CWMSForm>
+      </div>
+
+      <CodeBlock language="jsx">
+        {`// Hide either toolbar button as needed
+<CWMSSpreadsheet
+  columns={[
+    { key: "stage", label: "Stage (ft)", type: "number" },
+    { key: "flow", label: "Flow (cfs)", type: "number" },
+    { key: "temp", label: "Temp (°F)", type: "number" },
+  ]}
+  rows={5}
+  showCopyAllDataButton={false}
+  showSelectAllButton={false}
   defaultData={[
     ["650.2", "1250", "72.5"],
     ["650.3", "1275", "72.3"],

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -19,6 +19,8 @@ function CWMSSpreadsheet({
   showRowNumbers = true,
   showColumnHeaders = true,
   showTimestamps = false,
+  showCopyAllDataButton = true,
+  showSelectAllButton = true,
   timeoffsets = [],
   required = false,
   cellOverrides = {},
@@ -625,7 +627,6 @@ function CWMSSpreadsheet({
     }
     return label;
   };
-
   // Excel-like styles
   const containerStyle = {
     overflowX: "auto",
@@ -686,50 +687,62 @@ function CWMSSpreadsheet({
 
   return (
     <div>
-      <div style={{ marginBottom: "8px", display: "flex", gap: "8px" }}>
-        <button
-          onClick={copyAllData}
-          style={{
-            padding: "6px 12px",
-            backgroundColor: "#0969da",
-            color: "white",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-            fontSize: "13px",
-            fontFamily: "Arial, sans-serif",
-            display: "flex",
-            alignItems: "center",
-            gap: "6px",
-          }}
-          onMouseOver={(e) => (e.target.style.backgroundColor = "#0860ca")}
-          onMouseOut={(e) => (e.target.style.backgroundColor = "#0969da")}
-        >
-          📋 Copy All Data
-        </button>
-        <button
-          onClick={() => {
-            setDragStart({ row: 0, col: 0 });
-            setDragEnd({ row: visualRows - 1, col: visualCols - 1 });
-            // Focus on first cell to enable keyboard copy
-            document.getElementById(`${instanceId}-0-0`)?.focus();
-          }}
-          style={{
-            padding: "6px 12px",
-            backgroundColor: "#6c757d",
-            color: "white",
-            border: "none",
-            borderRadius: "4px",
-            cursor: "pointer",
-            fontSize: "13px",
-            fontFamily: "Arial, sans-serif",
-          }}
-          onMouseOver={(e) => (e.target.style.backgroundColor = "#5a6268")}
-          onMouseOut={(e) => (e.target.style.backgroundColor = "#6c757d")}
-        >
-          Select All
-        </button>
-      </div>
+      {(showCopyAllDataButton || showSelectAllButton) && (
+        <div style={{ marginBottom: "8px", display: "flex", gap: "8px" }}>
+          {showCopyAllDataButton && (
+            <button
+              type="button"
+              onClick={copyAllData}
+              style={{
+                padding: "6px 12px",
+                backgroundColor: "#0969da",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                cursor: "pointer",
+                fontSize: "13px",
+                fontFamily: "Arial, sans-serif",
+                display: "flex",
+                alignItems: "center",
+                gap: "6px",
+              }}
+              onMouseOver={(e) => (e.target.style.backgroundColor = "#0860ca")}
+              onMouseOut={(e) => (e.target.style.backgroundColor = "#0969da")}
+            >
+              📋 Copy All Data
+            </button>
+          )}
+
+          {showSelectAllButton && (
+            <button
+              type="button"
+              onClick={() => {
+                setDragStart({ row: 0, col: 0 });
+                setDragEnd({
+                  row: visualRows - 1,
+                  col: visualCols - 1,
+                });
+                document.getElementById(`${instanceId}-0-0`)?.focus();
+              }}
+              style={{
+                padding: "6px 12px",
+                backgroundColor: "#6c757d",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                cursor: "pointer",
+                fontSize: "13px",
+                fontFamily: "Arial, sans-serif",
+              }}
+              onMouseOver={(e) => (e.target.style.backgroundColor = "#5a6268")}
+              onMouseOut={(e) => (e.target.style.backgroundColor = "#6c757d")}
+            >
+              Select All
+            </button>
+          )}
+        </div>
+      )}
+
       <div style={containerStyle} ref={tableRef}>
         <table style={tableStyle}>
           {transpose ? (


### PR DESCRIPTION
Summary

Resolved issue 187 by adding props that allow the Select All and Copy All Data toolbar buttons to be hidden independently. Hiding both buttons leaves the spreadsheet visible.

The other change fixes unintended form submission when either button is used. Select All now selects the spreadsheet contents without submitting the form, and Copy All Data copies the spreadsheet contents without submitting the form.

Testing
Confirmed Copy All Data copies spreadsheet data without submitting the form
Confirmed Select All selects the spreadsheet without submitting the form
Confirmed each toolbar button can be hidden independently
Confirmed hiding both buttons leaves the spreadsheet visible
`npm run build`
`npm run build-docs`
`npm test` — 7 test files and 13 tests passed, on top of the manual testing just in case.

