### PR TITLE
Improve package output for tree shaking

### DIFF
--- a/.changeset/tree-shaking-package-output.md
+++ b/.changeset/tree-shaking-package-output.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": major
+---
+
+Improve package output for downstream tree shaking by publishing preserved ESM modules, adding subpath exports, moving styles to an explicit CSS entry, and lazy-loading Plotly and OpenLayers from the components that need them.

--- a/lib/components/data/forms/CWMSForm.jsx
+++ b/lib/components/data/forms/CWMSForm.jsx
@@ -1,7 +1,7 @@
 import React, { createContext, useRef, useState, useMemo } from "react";
 import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc.js";
+import timezone from "dayjs/plugin/timezone.js";
 import { Input, Field, Label, Button } from "@usace/groundwork";
 import { useAuth } from "../utilities/auth/useAuth";
 import { snapDayjs } from "./helpers/timeSnapping";

--- a/lib/components/data/maps/GageMap.jsx
+++ b/lib/components/data/maps/GageMap.jsx
@@ -7,9 +7,7 @@ import Map from "ol/Map";
 import View from "ol/View";
 import Overlay from "ol/Overlay";
 import OSM from "ol/source/OSM";
-import "ol/ol.css";
 
-import "../../../css/map.css";
 import { gwMerge } from "@usace/groundwork";
 
 function GageMap({ className }) {

--- a/lib/components/data/maps/GageMap.jsx
+++ b/lib/components/data/maps/GageMap.jsx
@@ -1,32 +1,52 @@
 /* eslint-disable react/prop-types */
 // MapComponent.js
 import { useEffect, useRef } from "react";
-import TileLayer from "ol/layer/Tile";
-
-import Map from "ol/Map";
-import View from "ol/View";
-import Overlay from "ol/Overlay";
-import OSM from "ol/source/OSM";
-
 import { gwMerge } from "@usace/groundwork";
 
 function GageMap({ className }) {
   const mapElement = useRef();
   useEffect(() => {
-    const osmLayer = new TileLayer({
-      preload: Infinity,
-      source: new OSM(),
-    });
+    let map;
+    let cancelled = false;
 
-    const map = new Map({
-      target: mapElement.current,
-      layers: [osmLayer],
-      view: new View({
-        center: [0, 0],
-        zoom: 0,
-      }),
-    });
-    return () => map.setTarget(null);
+    async function renderMap() {
+      const [
+        { default: TileLayer },
+        { default: Map },
+        { default: View },
+        { default: OSM },
+      ] = await Promise.all([
+        import("ol/layer/Tile"),
+        import("ol/Map"),
+        import("ol/View"),
+        import("ol/source/OSM"),
+      ]);
+
+      if (cancelled || !mapElement.current) {
+        return;
+      }
+
+      const osmLayer = new TileLayer({
+        preload: Infinity,
+        source: new OSM(),
+      });
+
+      map = new Map({
+        target: mapElement.current,
+        layers: [osmLayer],
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+    }
+
+    renderMap();
+
+    return () => {
+      cancelled = true;
+      map?.setTarget(null);
+    };
   }, []);
 
   return (

--- a/lib/components/data/plots/CWMSPlot.jsx
+++ b/lib/components/data/plots/CWMSPlot.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef } from "react";
 import { Configuration, LevelsApi, TimeSeriesApi } from "cwmsjs";
-import Plotly from "plotly.js-basic-dist";
 import { gwMerge, Skeleton } from "@usace/groundwork";
 import deepmerge from "deepmerge";
 import { useMemo } from "react";
@@ -352,11 +351,25 @@ export default function CWMSPlot({
       }
     }
 
-    setIsLoading(false);
+    let cancelled = false;
 
-    Plotly.newPlot(plotElement.current, traces, layout, {
-      responsive: responsive,
-    });
+    async function renderPlot() {
+      const { default: Plotly } = await import("plotly.js-basic-dist");
+      if (cancelled || !plotElement.current) {
+        return;
+      }
+
+      setIsLoading(false);
+      Plotly.newPlot(plotElement.current, traces, layout, {
+        responsive: responsive,
+      });
+    }
+
+    renderPlot();
+
+    return () => {
+      cancelled = true;
+    };
   }, [layout, locationLevelsArray, responsive, staticTraces, timeSeriesArray, tsData]);
 
   return (

--- a/lib/components/data/plots/TSPlot.jsx
+++ b/lib/components/data/plots/TSPlot.jsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from "react";
 import useCdaTimeSeries from "../hooks/useCdaTimeSeries";
-import Plotly from "plotly.js-basic-dist";
 
 /**
  * Component to fetch and plot timeseries data from the USACE CDA endpoint.
@@ -35,6 +34,8 @@ const TSPlot = ({
   // Plot the data with Plotly
   useEffect(() => {
     if (data && data.values) {
+      let cancelled = false;
+
       // Check for user inputs or use defaults
       // Set Defaults
       let plotTitle = data.name.split(".")[0];
@@ -88,9 +89,22 @@ const TSPlot = ({
         yaxis: { title: yaxisText },
       };
       if (layoutGrid) layout.grid = layoutGrid;
-      Plotly.newPlot(plotContainerRef.current, plotData, layout, {
-        responsive: responsive,
-      });
+      async function renderPlot() {
+        const { default: Plotly } = await import("plotly.js-basic-dist");
+        if (cancelled || !plotContainerRef.current) {
+          return;
+        }
+
+        Plotly.newPlot(plotContainerRef.current, plotData, layout, {
+          responsive: responsive,
+        });
+      }
+
+      renderPlot();
+
+      return () => {
+        cancelled = true;
+      };
     }
   }, [data, cdaParams, plotParams, shapes, annotations, layoutGrid, responsive]); // Re-plot when data changes
 

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -1,10 +1,3 @@
-// Bundle tailwind
-import "./css/tailwind.css";
-
-// Bundle groundwork-water styles
-import "@usace/groundwork/dist/style.css";
-import "react-toastify/dist/ReactToastify.css";
-
 // Import components
 import TSTable from "./components/data/tables/TSTable";
 import CWMSTable from "./components/data/tables/CWMSTable";

--- a/lib/style-entry.js
+++ b/lib/style-entry.js
@@ -1,0 +1,4 @@
+import "./style.css";
+import "@usace/groundwork/dist/style.css";
+import "react-toastify/dist/ReactToastify.css";
+import "ol/ol.css";

--- a/lib/style.css
+++ b/lib/style.css
@@ -1,0 +1,2 @@
+@import "./css/tailwind.css";
+@import "./css/map.css";

--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
       "types": "./types/lib/components/data/utilities/*.d.ts",
       "import": "./dist/es/components/data/utilities/*.js"
     },
+    "./style.css": {
+      "import": "./dist/style.css",
+      "require": "./dist/style.css"
+    },
     "./dist/*.css": {
       "import": "./dist/*.css",
       "require": "./dist/*.css"
@@ -71,7 +75,7 @@
     "link": "npm link && cd docs && npm link @usace-watermanagement/groundwork-water",
     "dev": "cd docs && npm run dev",
     "build": "npm run build-lib",
-    "build-lib": "tsc && vite build --mode lib",
+    "build-lib": "tsc && vite build --mode lib && vite build --mode css",
     "build-local": "npm run build-lib && npm run link",
     "build-docs": "cd docs && vite build",
     "build-docs-prod": "cd docs && vite build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Various",
   "description": "A library of react components for use with USACE Water Management Webpages",
   "main": "./dist/groundwork-water.umd.cjs",
-  "module": "./dist/groundwork-water.es.js",
+  "module": "./dist/es/index.js",
   "types": "types/lib/index.d.ts",
   "files": [
     "dist",
@@ -17,8 +17,48 @@
   "exports": {
     ".": {
       "types": "./types/lib/index.d.ts",
-      "import": "./dist/groundwork-water.es.js",
+      "import": "./dist/es/index.js",
       "require": "./dist/groundwork-water.umd.cjs"
+    },
+    "./auth/*": {
+      "types": "./types/lib/components/data/utilities/auth/*.d.ts",
+      "import": "./dist/es/components/data/utilities/auth/*.js"
+    },
+    "./cards/*": {
+      "types": "./types/lib/components/data/cards/*.d.ts",
+      "import": "./dist/es/components/data/cards/*.js"
+    },
+    "./dropdowns/*": {
+      "types": "./types/lib/components/data/dropdowns/*.d.ts",
+      "import": "./dist/es/components/data/dropdowns/*.js"
+    },
+    "./forms/*": {
+      "types": "./types/lib/components/data/forms/*.d.ts",
+      "import": "./dist/es/components/data/forms/*.js"
+    },
+    "./forms/inputs/*": {
+      "types": "./types/lib/components/data/forms/inputs/*.d.ts",
+      "import": "./dist/es/components/data/forms/inputs/*.js"
+    },
+    "./hooks/*": {
+      "types": "./types/lib/components/data/hooks/*.d.ts",
+      "import": "./dist/es/components/data/hooks/*.js"
+    },
+    "./maps/*": {
+      "types": "./types/lib/components/data/maps/*.d.ts",
+      "import": "./dist/es/components/data/maps/*.js"
+    },
+    "./plots/*": {
+      "types": "./types/lib/components/data/plots/*.d.ts",
+      "import": "./dist/es/components/data/plots/*.js"
+    },
+    "./tables/*": {
+      "types": "./types/lib/components/data/tables/*.d.ts",
+      "import": "./dist/es/components/data/tables/*.js"
+    },
+    "./utilities/*": {
+      "types": "./types/lib/components/data/utilities/*.d.ts",
+      "import": "./dist/es/components/data/utilities/*.js"
     },
     "./dist/*.css": {
       "import": "./dist/*.css",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,19 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "tailwindcss";
 import pkg from "./package.json";
 
+const externalPackages = [
+  ...Object.keys(pkg.dependencies ?? {}),
+  ...Object.keys(pkg.peerDependencies ?? {}),
+];
+const isExternalPackage = (id: string) =>
+  externalPackages.some((name) => id === name || id.startsWith(`${name}/`));
+const libraryAssetFileNames = (assetInfo: { name?: string }) => {
+  if (assetInfo.name?.endsWith(".css")) {
+    return "style.css";
+  }
+  return "assets/[name][extname]";
+};
+
 // Based off of Groundwork proper's lib vs doc config
 export default defineConfig(({ mode }) => {
   if (mode === "lib") {
@@ -18,31 +31,40 @@ export default defineConfig(({ mode }) => {
         minify: false,
         lib: {
           name: "GroundworkWater",
-          fileName: (format) => `groundwork-water.${format}.js`,
+          fileName: (format) =>
+            format === "umd" ? "groundwork-water.umd.cjs" : "index.js",
           entry: "lib/index.jsx",
           formats: ["es", "umd"],
           cssFileName: "style",
         },
         rollupOptions: {
-          external: [
-            "react",
-            "react-dom",
-            "@tanstack/react-query",
-            "ol",
-            "plotly.js-basic-dist",
-            "cwmsjs",
-            "@usace/groundwork",
-          ],
-          output: {
-            globals: {
-              react: "React",
-              "react-dom": "ReactDOM",
-              "@tanstack/react-query": "ReactQuery",
-              ol: "ol",
-              "plotly.js-basic-dist": "Plotly",
-              cwmsjs: "cwmsjs",
+          external: isExternalPackage,
+          output: [
+            {
+              format: "es",
+              dir: "dist",
+              preserveModules: true,
+              preserveModulesRoot: "lib",
+              entryFileNames: "es/[name].js",
+              chunkFileNames: "es/chunks/[name]-[hash].js",
+              assetFileNames: libraryAssetFileNames,
             },
-          },
+            {
+              format: "umd",
+              name: "GroundworkWater",
+              entryFileNames: "groundwork-water.umd.cjs",
+              assetFileNames: libraryAssetFileNames,
+              globals: {
+                react: "React",
+                "react-dom": "ReactDOM",
+                "@tanstack/react-query": "ReactQuery",
+                ol: "ol",
+                "plotly.js-basic-dist": "Plotly",
+                cwmsjs: "cwmsjs",
+                "@usace/groundwork": "Groundwork",
+              },
+            },
+          ],
         },
       },
     };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "tailwindcss";
 import pkg from "./package.json";
+import fs from "node:fs";
+import path from "node:path";
 
 const externalPackages = [
   ...Object.keys(pkg.dependencies ?? {}),
@@ -15,6 +17,15 @@ const libraryAssetFileNames = (assetInfo: { name?: string }) => {
   }
   return "assets/[name][extname]";
 };
+const removeCssEntrypointPlugin = (fileName: string) => ({
+  name: "remove-css-entrypoint",
+  closeBundle() {
+    const filePath = path.resolve("dist", fileName);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  },
+});
 
 // Based off of Groundwork proper's lib vs doc config
 export default defineConfig(({ mode }) => {
@@ -65,6 +76,26 @@ export default defineConfig(({ mode }) => {
               },
             },
           ],
+        },
+      },
+    };
+  } else if (mode === "css") {
+    console.log("Building library CSS");
+    return {
+      plugins: [react(), tailwindcss(), removeCssEntrypointPlugin("style-entry.js")],
+      publicDir: false,
+      build: {
+        emptyOutDir: false,
+        lib: {
+          entry: "lib/style-entry.js",
+          name: "GroundworkWaterStyles",
+          fileName: () => "style-entry.js",
+          formats: ["es"],
+        },
+        rollupOptions: {
+          output: {
+            assetFileNames: libraryAssetFileNames,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary

Improves the library package output so apps can import hooks, cards, maps, tables, and plots without loading unrelated browser-heavy code:

- publish preserved ESM modules alongside the existing UMD build
- expose subpath exports for the main component groups
- move CSS to an explicit stylesheet entry
- lazy-load Plotly and OpenLayers usage from the components that need them

## Bundle check

Package pack size:

| Package | Before | After |
| --- | ---: | ---: |
| Packed tarball | 431.9 KB | 91.3 KB |
| Unpacked package | 2.18 MB | 444.9 KB |

Representative downstream bundles:

| Import | Before | After | Gzip before | Gzip after |
| --- | ---: | ---: | ---: | ---: |
| `useDebounce` | 1.56 MB | 193.5 KB | 520.3 KB | 60.3 KB |
| `CdaLatestValueCard` | 1.60 MB | 274.5 KB | 533.9 KB | 84.2 KB |
| `CWMSPlot` | 1.60 MB | 1.40 MB | 530.6 KB | 464.8 KB |

## Validation

- `npm run build-local`
- `npm run build-docs`
- packed the library and tested representative downstream bundles

Related: #231, #110, #259