### PR TITLE
Refine Dependabot update checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      # 0.5.x requires ESLint 9 and flat config. Keep compatible 0.4.x
+      # patches flowing until the repository completes that migration.
+      - dependency-name: "eslint-plugin-react-refresh"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       library-minor-and-patch:
         applies-to: "version-updates"
@@ -45,6 +52,11 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      - dependency-name: "eslint-plugin-react-refresh"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       docs-minor-and-patch:
         applies-to: "version-updates"

--- a/.github/workflows/changesets_check.yml
+++ b/.github/workflows/changesets_check.yml
@@ -19,6 +19,11 @@ jobs:
 
       - run: git fetch origin main:main
 
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
       - name: Determine whether a changeset is required
         id: changeset
         shell: bash
@@ -28,20 +33,43 @@ jobs:
           if [[ "$HEAD_REF" == "changeset-release/main" ]]; then
             echo "required=false" >> "$GITHUB_OUTPUT"
             echo "Skipping validation for the Changesets release pull request."
-          elif git diff --quiet main...HEAD -- . \
-            ":(exclude)package-lock.json" \
-            ":(exclude)docs/**"; then
-            echo "required=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping validation for a lockfile/docs-only pull request."
-          else
-            echo "required=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Setup Node
-        if: steps.changeset.outputs.required == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 20
+          mapfile -t release_files < <(
+            git diff --name-only main...HEAD -- . \
+              ":(exclude)package-lock.json" \
+              ":(exclude)docs/**"
+          )
+
+          if [[ ${#release_files[@]} -eq 0 ]]; then
+            echo "required=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping validation for a lockfile/docs-only pull request."
+            exit 0
+          fi
+
+          if [[ ${#release_files[@]} -eq 1 && "${release_files[0]}" == "package.json" ]]; then
+            git show main:package.json > "$RUNNER_TEMP/main-package.json"
+            if node <<'NODE'; then
+          const fs = require("node:fs");
+
+          const base = JSON.parse(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/main-package.json`, "utf8"),
+          );
+          const head = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+          delete base.devDependencies;
+          delete head.devDependencies;
+
+          process.exit(JSON.stringify(base) === JSON.stringify(head) ? 0 : 1);
+          NODE
+              echo "required=false" >> "$GITHUB_OUTPUT"
+              echo "Skipping validation for a devDependency-only pull request."
+              exit 0
+            fi
+          fi
+
+          echo "required=true" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         if: steps.changeset.outputs.required == 'true'


### PR DESCRIPTION
## Summary

- Hold `eslint-plugin-react-refresh` at compatible `0.4.x` releases until the ESLint 9 migration
- Skip Changesets for devDependency-only manifest updates
- Preserve Changesets enforcement for published dependencies, metadata, source, and mixed changes

This lets Dependabot regenerate the routine groups without the ESLint peer conflict and unblocks release-free tooling upgrades.

## Checks

- Parsed and formatted workflow/config YAML
- Validated embedded Bash syntax
- Tested decisions against PRs #256, #299, #300, and #302 plus a library-source branch
- Confirmed no package release is produced
