### PR TITLE
Add expiry-aware auth token refresh

### DIFF
--- a/.changeset/fresh-swagger-auth.md
+++ b/.changeset/fresh-swagger-auth.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add `getValidToken(minValiditySeconds)` to authentication methods so API clients can retrieve a usable Keycloak access token immediately before sending a request. The Keycloak implementation refreshes expired or soon-to-expire PKCE and direct-grant tokens and coalesces concurrent refresh attempts into one request.

--- a/docs/src/pages/docs/auth/auth-method.jsx
+++ b/docs/src/pages/docs/auth/auth-method.jsx
@@ -25,6 +25,12 @@ const componentProps = [
     desc: "A function that returns the authentication status of the user.",
   },
   {
+    name: "getValidToken",
+    type: "(minValiditySeconds?: number) => Promise<string | undefined>",
+    default: "undefined",
+    desc: "Optional - Returns a usable access token, refreshing it first when it is expired or nearing expiration.",
+  },
+  {
     name: "refresh",
     type: "() => Promise<void>",
     default: "undefined",

--- a/docs/src/pages/docs/auth/keycloak.jsx
+++ b/docs/src/pages/docs/auth/keycloak.jsx
@@ -104,7 +104,10 @@ function KeycloakDocs() {
         </Text>
         <Text className="mt-4">
           This authentication method uses refresh tokens and will automatically manage
-          requests and updates for the current access token. The interval between
+          requests and updates for the current access token. Call
+          <Code> getValidToken(minValiditySeconds)</Code> immediately before an API
+          request to refresh an expired or soon-to-expire token on demand. Concurrent
+          callers share a single refresh request. The interval between background
           refresh requests can be controlled by the refreshInterval option.
         </Text>
         <Text className="mt-4">

--- a/lib/components/data/utilities/auth/AuthProvider.tsx
+++ b/lib/components/data/utilities/auth/AuthProvider.tsx
@@ -9,6 +9,7 @@ export interface AuthMethod {
   login: (options?: AuthLoginOptions) => Promise<void>;
   logout: () => Promise<void>;
   isAuth: () => Promise<boolean>;
+  getValidToken?: (minValiditySeconds?: number) => Promise<string | undefined>;
   refresh?: () => Promise<void>;
   refreshInterval?: number;
   statusPollInterval?: number;

--- a/lib/components/data/utilities/auth/__tests__/keycloakAuthMethod.test.ts
+++ b/lib/components/data/utilities/auth/__tests__/keycloakAuthMethod.test.ts
@@ -11,6 +11,18 @@ const mockOidcClient = {
   signoutRedirect: vi.fn(),
 };
 
+const tokenResponse = (accessToken: string, refreshToken: string, expiresIn = 300) => ({
+  access_token: accessToken,
+  expires_in: expiresIn,
+  refresh_token: refreshToken,
+  refresh_expires_in: 1800,
+  id_token: "id-token",
+  token_type: "Bearer",
+  not_before_policy: 0,
+  session_state: "session",
+  scope: "openid profile",
+});
+
 vi.mock("../keycloakOidcClient", () => ({
   createKeycloakOidcClient: vi.fn(() => mockOidcClient),
 }));
@@ -24,6 +36,8 @@ describe("createKeycloakAuthMethod", () => {
       access_token: "token",
       refresh_token: "refresh",
       expired: false,
+      expires_at: Date.now() / 1000 + 300,
+      expires_in: 300,
     });
   });
 
@@ -89,5 +103,128 @@ describe("createKeycloakAuthMethod", () => {
     expect(window.location.href).toBe(
       `${window.location.origin}/app/callback?office=SWT#/docs/auth`,
     );
+  });
+
+  it("returns a current PKCE token without refreshing it", async () => {
+    const method = createKeycloakAuthMethod({
+      host: "https://identity.example.test/auth",
+      realm: "cwbi",
+      client: "cwms",
+    });
+
+    await expect(method.getValidToken?.()).resolves.toBe("token");
+    expect(mockOidcClient.signinSilent).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an expiring PKCE token before returning it", async () => {
+    mockOidcClient.getUser
+      .mockResolvedValueOnce({
+        access_token: "old-token",
+        refresh_token: "old-refresh",
+        expired: false,
+        expires_at: Date.now() / 1000 + 30,
+        expires_in: 30,
+      })
+      .mockResolvedValue({
+        access_token: "new-token",
+        refresh_token: "new-refresh",
+        expired: false,
+        expires_at: Date.now() / 1000 + 300,
+        expires_in: 300,
+      });
+
+    const method = createKeycloakAuthMethod({
+      host: "https://identity.example.test/auth",
+      realm: "cwbi",
+      client: "cwms",
+    });
+
+    await expect(method.getValidToken?.(60)).resolves.toBe("new-token");
+    expect(mockOidcClient.signinSilent).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent PKCE refresh requests", async () => {
+    let finishRefresh: (() => void) | undefined;
+    mockOidcClient.getUser.mockResolvedValue({
+      access_token: "old-token",
+      refresh_token: "old-refresh",
+      expired: false,
+      expires_at: Date.now() / 1000 + 30,
+      expires_in: 30,
+    });
+    mockOidcClient.signinSilent.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        }),
+    );
+
+    const method = createKeycloakAuthMethod({
+      host: "https://identity.example.test/auth",
+      realm: "cwbi",
+      client: "cwms",
+    });
+
+    const firstToken = method.getValidToken?.(60);
+    const secondToken = method.getValidToken?.(60);
+    await vi.waitFor(() =>
+      expect(mockOidcClient.signinSilent).toHaveBeenCalledTimes(1),
+    );
+
+    mockOidcClient.getUser.mockResolvedValue({
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expired: false,
+      expires_at: Date.now() / 1000 + 300,
+      expires_in: 300,
+    });
+    finishRefresh?.();
+
+    await expect(Promise.all([firstToken, secondToken])).resolves.toEqual([
+      "new-token",
+      "new-token",
+    ]);
+  });
+
+  it("refreshes a direct-grant token when used after five minutes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-31T12:00:00Z"));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(tokenResponse("old-token", "old-refresh")),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(tokenResponse("new-token", "new-refresh")),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const method = createKeycloakAuthMethod({
+        host: "https://identity.example.test/auth",
+        realm: "cwbi",
+        client: "cwms",
+        flow: "direct-grant",
+        username: "user",
+        password: "password",
+      });
+
+      await method.login();
+      vi.advanceTimersByTime(5 * 60 * 1000);
+
+      await expect(method.getValidToken?.(60)).resolves.toBe("new-token");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][1]?.body.toString()).toContain(
+        "grant_type=refresh_token",
+      );
+      expect(fetchMock.mock.calls[1][1]?.body.toString()).toContain(
+        "refresh_token=old-refresh",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
   });
 });

--- a/lib/components/data/utilities/auth/keycloakAuthMethod.ts
+++ b/lib/components/data/utilities/auth/keycloakAuthMethod.ts
@@ -88,6 +88,8 @@ export const createKeycloakAuthMethod = ({
 }: KeycloakAuthConfig) => {
   let accessToken: string | undefined;
   let refreshToken: string | undefined;
+  let accessTokenExpiresAt: number | undefined;
+  let refreshInFlight: Promise<void> | undefined;
   let pkceCallbackHandled = false;
   const loginReturnToStorageKey = getLoginReturnToStorageKey(realm, client);
   const normalizedHost = normalizeKeycloakHost(host);
@@ -111,7 +113,14 @@ export const createKeycloakAuthMethod = ({
     const user = await oidcClient.getUser();
     accessToken = user?.access_token;
     refreshToken = user?.refresh_token;
+    accessTokenExpiresAt = user?.expires_at;
     return !!user?.access_token;
+  };
+
+  const storeDirectGrantTokens = (tokenResponse: KeycloakTokenResponse) => {
+    accessToken = tokenResponse.access_token;
+    refreshToken = tokenResponse.refresh_token;
+    accessTokenExpiresAt = Date.now() / 1000 + tokenResponse.expires_in;
   };
 
   const getOidcUser = async () => {
@@ -155,6 +164,7 @@ export const createKeycloakAuthMethod = ({
   const clearPkceState = async () => {
     accessToken = undefined;
     refreshToken = undefined;
+    accessTokenExpiresAt = undefined;
     pkceCallbackHandled = false;
 
     if (!oidcClient) return;
@@ -268,14 +278,14 @@ export const createKeycloakAuthMethod = ({
     if (!loginData) throw new Error("Invalid flow provided for keycloak auth config");
     const tokenResponse = await fetchKeycloakRequest("token", loginData);
     const tokenJson: KeycloakTokenResponse = await tokenResponse.json();
-    accessToken = tokenJson.access_token;
-    refreshToken = tokenJson.refresh_token;
+    storeDirectGrantTokens(tokenJson);
   };
 
   const logout = async () => {
     if (flow === "authorization-code-pkce") {
       accessToken = undefined;
       refreshToken = undefined;
+      accessTokenExpiresAt = undefined;
       pkceCallbackHandled = false;
 
       if (!oidcClient) throw new Error("Invalid PKCE auth client configuration");
@@ -294,6 +304,7 @@ export const createKeycloakAuthMethod = ({
     }
     accessToken = undefined;
     refreshToken = undefined;
+    accessTokenExpiresAt = undefined;
   };
 
   const isAuth = async () => {
@@ -321,16 +332,18 @@ export const createKeycloakAuthMethod = ({
         if (!user) {
           accessToken = undefined;
           refreshToken = undefined;
+          accessTokenExpiresAt = undefined;
           return false;
         }
 
         if (!user.expired) {
           accessToken = user.access_token;
           refreshToken = user.refresh_token;
+          accessTokenExpiresAt = user.expires_at;
           return true;
         }
 
-        await oidcClient.signinSilent();
+        await refresh();
         return syncTokensFromOidcUser();
       } catch (error) {
         console.error("Failed to process keycloak PKCE auth state", error);
@@ -342,7 +355,7 @@ export const createKeycloakAuthMethod = ({
     return !!accessToken;
   };
 
-  const refresh = async () => {
+  async function performRefresh() {
     if (flow === "authorization-code-pkce") {
       if (!oidcClient) throw new Error("Invalid PKCE auth client configuration");
 
@@ -363,14 +376,60 @@ export const createKeycloakAuthMethod = ({
     };
     const refreshResponse = await fetchKeycloakRequest("token", refreshData);
     const tokenJson: KeycloakTokenResponse = await refreshResponse.json();
-    accessToken = tokenJson.access_token;
-    refreshToken = tokenJson.refresh_token;
+    storeDirectGrantTokens(tokenJson);
+  }
+
+  const refresh = async () => {
+    if (!refreshInFlight) {
+      refreshInFlight = performRefresh();
+    }
+
+    const currentRefresh = refreshInFlight;
+    try {
+      await currentRefresh;
+    } finally {
+      if (refreshInFlight === currentRefresh) {
+        refreshInFlight = undefined;
+      }
+    }
+  };
+
+  const getValidToken = async (minValiditySeconds = 60) => {
+    if (flow === "authorization-code-pkce") {
+      const user = await getOidcUser();
+      if (!user?.access_token) {
+        accessToken = undefined;
+        refreshToken = undefined;
+        accessTokenExpiresAt = undefined;
+        return undefined;
+      }
+
+      accessToken = user.access_token;
+      refreshToken = user.refresh_token;
+      accessTokenExpiresAt = user.expires_at;
+
+      if (user.expired || (user.expires_in ?? Infinity) <= minValiditySeconds) {
+        await refresh();
+      }
+
+      return accessToken;
+    }
+
+    if (!accessToken) return undefined;
+
+    const refreshAt = Date.now() / 1000 + minValiditySeconds;
+    if (accessTokenExpiresAt !== undefined && accessTokenExpiresAt <= refreshAt) {
+      await refresh();
+    }
+
+    return accessToken;
   };
 
   const keycloakAuthMethod: AuthMethod = {
     login,
     logout,
     isAuth,
+    getValidToken,
     refresh,
     refreshInterval,
     get token() {


### PR DESCRIPTION
## Summary

- Add `getValidToken(minValiditySeconds)` to authentication methods.
- Refresh PKCE and direct-grant tokens only when they are expired or nearing expiry.
- Coalesce concurrent refresh attempts into a single request.
- Document the API and include a minor changeset.

## Why

Consumers such as Swagger UI need to guarantee that a bearer token is valid immediately before an API request is sent. The existing refresh polling runs through `AuthProvider`, so consumers that instantiate an auth method directly can otherwise retain a stale access token.

## Impact

This is a backward-compatible, optional addition to the `AuthMethod` interface. Existing refresh and polling behavior remains available. A changeset is included; downstream CDA should target the actual package version published from this change.

## Validation

- `npm test` — 7 test files, 17 tests passed.
- `npm run build-lib`.
- Prettier and whitespace checks.
- Local CDA/Keycloak integration with a 300-second token lifespan: a secured Swagger request returned HTTP 200 before expiry and again after more than six minutes idle, without reauthentication.