### PR TITLE
Add interactive BasinPie charts

### DIFF
--- a/.changeset/bright-pies-share.md
+++ b/.changeset/bright-pies-share.md
@@ -1,0 +1,6 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add a secure interactive radial fill chart, a CWMS basin storage adapter, and exact
+level time-series fetching helpers for dynamic request lists.

--- a/docs/src/bundles/route-bundle.js
+++ b/docs/src/bundles/route-bundle.js
@@ -4,6 +4,7 @@ import CdaLatestValueCardDocs from "../pages/docs/cards/cda-latest-value-card";
 import NotFound from "../pages/NotFound";
 import PlotsDocs from "../pages/docs/plots";
 import CWMSPlotDocs from "../pages/docs/plots/cwms-plot";
+import BasinPieDocs from "../pages/docs/plots/basin-pie";
 import Tables from "../pages/docs/tables";
 import Maps from "../pages/docs/maps";
 import Docs from "../pages/docs/";
@@ -78,6 +79,7 @@ export default createRouteBundle(
     "/docs/hooks/use-cda-blobs": useCdaBlobs,
     "/docs/plots": PlotsDocs,
     "/docs/plots/cwms-plot": CWMSPlotDocs,
+    "/docs/plots/basin-pie": BasinPieDocs,
     "/docs/maps": Maps,
     "/docs/tables": Tables,
     "/docs/summary/data-status": DataStatus,

--- a/docs/src/nav-links.js
+++ b/docs/src/nav-links.js
@@ -164,6 +164,11 @@ export default [
         text: "CWMS Plot",
         href: `${BASE_URL}#/docs/plots/cwms-plot`,
       },
+      {
+        id: "basin-pie",
+        text: "Basin Pie",
+        href: `${BASE_URL}#/docs/plots/basin-pie`,
+      },
     ],
   },
   {

--- a/docs/src/pages/docs/hooks/use-cda-levels.jsx
+++ b/docs/src/pages/docs/hooks/use-cda-levels.jsx
@@ -106,6 +106,12 @@ function UseCdaLevels() {
             CWMSPlot
           </Link>
         </Text>
+        <Text className="mt-2">
+          This hook uses the exact <Code>/levels/&#123;level-id&#125;/timeseries</Code>{" "}
+          endpoint rather than the slower wildcard levels listing endpoint. Dynamic
+          request lists can use <Code>fetchCdaLevelValues</Code>, which uses the same
+          operation and keys results by each requested level ID.
+        </Text>
         <QueryClientWarning />
       </div>
       <Divider text="Example Usage" className="mt-8" />

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -19,7 +19,6 @@ const levels = {
 const timeSeries = {
   "ALFA.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 72],
   "BRAV.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 96],
-  "CHAR.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, -901],
 };
 
 const radialSegments = [
@@ -51,11 +50,7 @@ const timeSeriesData = {
     "2026-08-07T12:00:00Z",
     96,
   ],
-  // -901 is rendered as a missing-storage segment.
-  "CHAR.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [
-    "2026-08-07T12:00:00Z",
-    -901,
-  ],
+  // Omitting CHAR's series renders it as a missing-storage segment.
 };
 
 <BasinPie

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Code, Divider, Text, UsaceBox } from "@usace/groundwork";
+import { BasinPie, RadialFillChart } from "../../../../../lib";
+import { Code as CodeBlock } from "../../components/code.jsx";
+import DocsPage from "../_docs-wrapper";
+
+const levels = {
+  "ALFA.Stor.Inst.0.Top of Flood": [0, 220],
+  "ALFA.Stor.Inst.0.Top of Conservation": [0, 160],
+  "ALFA.Stor.Inst.0.Top of Inactive": [0, 40],
+  "BRAV.Stor.Inst.0.Top of Flood": [0, 180],
+  "BRAV.Stor.Inst.0.Top of Conservation": [0, 140],
+  "BRAV.Stor.Inst.0.Top of Inactive": [0, 20],
+  "CHAR.Stor.Inst.0.Top of Flood": [0, 150],
+  "CHAR.Stor.Inst.0.Top of Conservation": [0, 110],
+  "CHAR.Stor.Inst.0.Top of Inactive": [0, 30],
+};
+
+const timeSeries = {
+  "ALFA.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 72],
+  "BRAV.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 96],
+  "CHAR.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, -901],
+};
+
+const radialSegments = [
+  { id: "north", label: "North", weight: 120, fillRatio: 0.6 },
+  { id: "south", label: "South", weight: 80, fillRatio: 0.35 },
+  { id: "west", label: "West", weight: 60, fillRatio: null },
+];
+
+function BasinPieDocs() {
+  const [selected, setSelected] = useState("None");
+
+  return (
+    <DocsPage
+      middleText="Basin Pie"
+      prevUrl="/docs/plots/cwms-plot"
+      prevText="CWMS Plot"
+    >
+      <UsaceBox title="Basin Pie">
+        <Text>
+          BasinPie converts already-loaded CWMS storage levels and time-series values
+          into an interactive basin storage graphic. Data fetching remains controlled by
+          the consuming application.
+        </Text>
+        <div className="gw-mx-auto gw-max-w-3xl gw-text-center">
+          <BasinPie
+            id="basin-pie-example"
+            projects={["ALFA", "BRAV", "CHAR"]}
+            levelData={levels}
+            timeSeriesData={timeSeries}
+            pool="conservation"
+            asOf="2026-08-07T12"
+            onProjectSelect={setSelected}
+          />
+          <Text>Selected project: {selected}</Text>
+        </div>
+      </UsaceBox>
+
+      <Divider text="Generic radial chart" className="gw-mt-8" />
+      <Text className="gw-mb-3">
+        RadialFillChart accepts normalized data and has no CWMS-specific behavior.
+      </Text>
+      <div className="gw-mx-auto gw-max-w-3xl">
+        <RadialFillChart
+          segments={radialSegments}
+          title="Example radial fill chart"
+          ariaLabel="Example radial fill chart"
+        />
+      </div>
+
+      <Divider text="Usage" className="gw-mt-8" />
+      <CodeBlock language="jsx">
+        {`import { BasinPie } from "@usace-watermanagement/groundwork-water";
+
+<BasinPie
+  projects={["ALFA", "BRAV", "CHAR"]}
+  pool="conservation"
+  levelData={levelData}
+  timeSeriesData={timeSeriesData}
+  asOf="2026-08-07T12"
+  onProjectSelect={(projectId) => navigate(\`/project/\${encodeURIComponent(projectId)}\`)}
+/>`}
+      </CodeBlock>
+      <div className="gw-font-bold gw-text-lg gw-pt-6">
+        Component APIs: <Code className="gw-p-2">{`<BasinPie />`}</Code> and{" "}
+        <Code className="gw-p-2">{`<RadialFillChart />`}</Code>
+      </div>
+    </DocsPage>
+  );
+}
+
+export default BasinPieDocs;

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -16,7 +16,7 @@ const levels = {
   "CHAR.Stor.Inst.0.Top of Inactive": [0, 30],
 };
 
-const timeSeries = {
+const fixtureTsData = {
   "ALFA.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 72],
   "BRAV.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 96],
 };
@@ -41,7 +41,7 @@ const levelData = {
   "CHAR.Stor.Inst.0.Top of Inactive": ["2026-08-07T12:00:00Z", 30],
 };
 
-const timeSeriesData = {
+const tsData = {
   "ALFA.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [
     "2026-08-07T12:00:00Z",
     72,
@@ -57,8 +57,32 @@ const timeSeriesData = {
   projects={["ALFA", "BRAV", "CHAR"]}
   pool="conservation"
   levelData={levelData}
-  timeSeriesData={timeSeriesData}
+  tsData={tsData}
   asOf="2026-08-07T12"
+  onProjectSelect={(projectId) =>
+    navigate(\`/project/\${encodeURIComponent(projectId)}\`)
+  }
+/>`;
+
+const basinPieFetchExample = `import { BasinPie } from "@usace-watermanagement/groundwork-water";
+
+const projects = ["ALFA", "BRAV", "CHAR"];
+const levelIds = projects.flatMap((project) => [
+  \`\${project}.Stor.Inst.0.Top of Flood\`,
+  \`\${project}.Stor.Inst.0.Top of Conservation\`,
+  \`\${project}.Stor.Inst.0.Top of Inactive\`,
+]);
+const tsids = projects.map(
+  (project) =>
+    \`\${project}.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev\`,
+);
+
+<BasinPie
+  projects={projects}
+  pool="conservation"
+  office="SWT"
+  levelIds={levelIds}
+  tsids={tsids}
   onProjectSelect={(projectId) =>
     navigate(\`/project/\${encodeURIComponent(projectId)}\`)
   }
@@ -92,7 +116,8 @@ function BasinPieDocs() {
         <Text>
           BasinPie converts already-loaded CWMS storage levels and time-series values
           into an interactive basin storage graphic. Data fetching remains controlled by
-          the consuming application.
+          the consuming application when levelData and tsData are provided. In this
+          mode, no office is needed because BasinPie makes no CDA requests.
         </Text>
         <div
           className="gw-mx-auto gw-max-w-3xl gw-text-center"
@@ -102,14 +127,25 @@ function BasinPieDocs() {
             id="basin-pie-example"
             projects={["ALFA", "BRAV", "CHAR"]}
             levelData={levels}
-            timeSeriesData={timeSeries}
+            tsData={fixtureTsData}
             pool="conservation"
             asOf="2026-08-07T12"
             onProjectSelect={setSelected}
           />
           <Text>Selected project: {selected}</Text>
         </div>
+        <Text className="gw-font-bold gw-mt-4">
+          Using data already loaded by the app
+        </Text>
         <CodeBlock language="jsx">{basinPieExample}</CodeBlock>
+        <Text className="gw-font-bold gw-mt-6">Loading identifiers from CDA</Text>
+        <Text>
+          Provide office, levelIds, and tsids to let BasinPie load missing datasets.
+          Level IDs use CDA&apos;s level time-series endpoint; TSIDs use the standard
+          time-series endpoint. The default window is the three hours ending now and can
+          be overridden with begin and end.
+        </Text>
+        <CodeBlock language="jsx">{basinPieFetchExample}</CodeBlock>
       </UsaceBox>
 
       <Divider text="Generic radial chart" className="gw-mt-8" />

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -28,6 +28,34 @@ const radialSegments = [
   { id: "west", label: "West", weight: 60, fillRatio: null },
 ];
 
+const basinPieExample = `import { BasinPie } from "@usace-watermanagement/groundwork-water";
+
+<BasinPie
+  projects={["ALFA", "BRAV", "CHAR"]}
+  pool="conservation"
+  levelData={levelData}
+  timeSeriesData={timeSeriesData}
+  asOf="2026-08-07T12"
+  onProjectSelect={(projectId) =>
+    navigate(\`/project/\${encodeURIComponent(projectId)}\`)
+  }
+/>`;
+
+const radialFillChartExample = `import { RadialFillChart } from "@usace-watermanagement/groundwork-water";
+
+const segments = [
+  { id: "north", label: "North", weight: 120, fillRatio: 0.6 },
+  { id: "south", label: "South", weight: 80, fillRatio: 0.35 },
+  { id: "west", label: "West", weight: 60, fillRatio: null },
+];
+
+<RadialFillChart
+  segments={segments}
+  title="Example radial fill chart"
+  ariaLabel="Example radial fill chart"
+  onSegmentSelect={(segment) => console.log(segment.id)}
+/>`;
+
 function BasinPieDocs() {
   const [selected, setSelected] = useState("None");
 
@@ -43,7 +71,10 @@ function BasinPieDocs() {
           into an interactive basin storage graphic. Data fetching remains controlled by
           the consuming application.
         </Text>
-        <div className="gw-mx-auto gw-max-w-3xl gw-text-center">
+        <div
+          className="gw-mx-auto gw-max-w-3xl gw-text-center"
+          style={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+        >
           <BasinPie
             id="basin-pie-example"
             projects={["ALFA", "BRAV", "CHAR"]}
@@ -55,33 +86,24 @@ function BasinPieDocs() {
           />
           <Text>Selected project: {selected}</Text>
         </div>
+        <CodeBlock language="jsx">{basinPieExample}</CodeBlock>
       </UsaceBox>
 
       <Divider text="Generic radial chart" className="gw-mt-8" />
       <Text className="gw-mb-3">
         RadialFillChart accepts normalized data and has no CWMS-specific behavior.
       </Text>
-      <div className="gw-mx-auto gw-max-w-3xl">
+      <div
+        className="gw-mx-auto gw-max-w-3xl"
+        style={{ display: "flex", justifyContent: "center" }}
+      >
         <RadialFillChart
           segments={radialSegments}
           title="Example radial fill chart"
           ariaLabel="Example radial fill chart"
         />
       </div>
-
-      <Divider text="Usage" className="gw-mt-8" />
-      <CodeBlock language="jsx">
-        {`import { BasinPie } from "@usace-watermanagement/groundwork-water";
-
-<BasinPie
-  projects={["ALFA", "BRAV", "CHAR"]}
-  pool="conservation"
-  levelData={levelData}
-  timeSeriesData={timeSeriesData}
-  asOf="2026-08-07T12"
-  onProjectSelect={(projectId) => navigate(\`/project/\${encodeURIComponent(projectId)}\`)}
-/>`}
-      </CodeBlock>
+      <CodeBlock language="jsx">{radialFillChartExample}</CodeBlock>
       <div className="gw-font-bold gw-text-lg gw-pt-6">
         Component APIs: <Code className="gw-p-2">{`<BasinPie />`}</Code> and{" "}
         <Code className="gw-p-2">{`<RadialFillChart />`}</Code>

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -27,6 +27,28 @@ const radialSegments = [
   { id: "west", label: "West", weight: 60, fillRatio: null },
 ];
 
+const cdaProjects = ["KEYS", "KAWL"];
+const cdaLevelIds = cdaProjects.flatMap((project) => [
+  `${project}.Stor.Inst.0.Top of Flood`,
+  `${project}.Stor.Inst.0.Top of Conservation`,
+  `${project}.Stor.Inst.0.Top of Inactive`,
+]);
+const cdaTsids = cdaProjects.map(
+  (project) => `${project}.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev`,
+);
+const cdaPreviewLevels = {
+  "KEYS.Stor.Inst.0.Top of Flood": [0, 500],
+  "KEYS.Stor.Inst.0.Top of Conservation": [0, 350],
+  "KEYS.Stor.Inst.0.Top of Inactive": [0, 50],
+  "KAWL.Stor.Inst.0.Top of Flood": [0, 600],
+  "KAWL.Stor.Inst.0.Top of Conservation": [0, 400],
+  "KAWL.Stor.Inst.0.Top of Inactive": [0, 100],
+};
+const cdaPreviewTsData = {
+  "KEYS.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 225],
+  "KAWL.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [0, 150],
+};
+
 const basinPieExample = `import { BasinPie } from "@usace-watermanagement/groundwork-water";
 
 const levelData = {
@@ -66,7 +88,7 @@ const tsData = {
 
 const basinPieFetchExample = `import { BasinPie } from "@usace-watermanagement/groundwork-water";
 
-const projects = ["ALFA", "BRAV", "CHAR"];
+const projects = ["KEYS", "KAWL"];
 const levelIds = projects.flatMap((project) => [
   \`\${project}.Stor.Inst.0.Top of Flood\`,
   \`\${project}.Stor.Inst.0.Top of Conservation\`,
@@ -105,6 +127,7 @@ const segments = [
 
 function BasinPieDocs() {
   const [selected, setSelected] = useState("None");
+  const [cdaSelected, setCdaSelected] = useState("None");
 
   return (
     <DocsPage
@@ -118,6 +141,9 @@ function BasinPieDocs() {
           into an interactive basin storage graphic. Data fetching remains controlled by
           the consuming application when levelData and tsData are provided. In this
           mode, no office is needed because BasinPie makes no CDA requests.
+        </Text>
+        <Text className="gw-font-bold gw-mt-4">
+          Using data already loaded by the app
         </Text>
         <div
           className="gw-mx-auto gw-max-w-3xl gw-text-center"
@@ -134,9 +160,6 @@ function BasinPieDocs() {
           />
           <Text>Selected project: {selected}</Text>
         </div>
-        <Text className="gw-font-bold gw-mt-4">
-          Using data already loaded by the app
-        </Text>
         <CodeBlock language="jsx">{basinPieExample}</CodeBlock>
         <Text className="gw-font-bold gw-mt-6">Loading identifiers from CDA</Text>
         <Text>
@@ -145,6 +168,28 @@ function BasinPieDocs() {
           time-series endpoint. The default window is the three hours ending now and can
           be overridden with begin and end.
         </Text>
+        <Text>
+          This chart uses fixed representative responses so the documentation remains
+          available when CDA is offline. The example below it omits those data props and
+          performs the live requests.
+        </Text>
+        <div
+          className="gw-mx-auto gw-max-w-3xl gw-text-center"
+          style={{ display: "flex", flexDirection: "column", alignItems: "center" }}
+        >
+          <BasinPie
+            id="basin-pie-cda-example"
+            projects={cdaProjects}
+            pool="conservation"
+            office="SWT"
+            levelIds={cdaLevelIds}
+            tsids={cdaTsids}
+            levelData={cdaPreviewLevels}
+            tsData={cdaPreviewTsData}
+            onProjectSelect={setCdaSelected}
+          />
+          <Text>Selected project: {cdaSelected}</Text>
+        </div>
         <CodeBlock language="jsx">{basinPieFetchExample}</CodeBlock>
       </UsaceBox>
 

--- a/docs/src/pages/docs/plots/basin-pie.jsx
+++ b/docs/src/pages/docs/plots/basin-pie.jsx
@@ -30,6 +30,34 @@ const radialSegments = [
 
 const basinPieExample = `import { BasinPie } from "@usace-watermanagement/groundwork-water";
 
+const levelData = {
+  "ALFA.Stor.Inst.0.Top of Flood": ["2026-08-07T12:00:00Z", 220],
+  "ALFA.Stor.Inst.0.Top of Conservation": ["2026-08-07T12:00:00Z", 160],
+  "ALFA.Stor.Inst.0.Top of Inactive": ["2026-08-07T12:00:00Z", 40],
+  "BRAV.Stor.Inst.0.Top of Flood": ["2026-08-07T12:00:00Z", 180],
+  "BRAV.Stor.Inst.0.Top of Conservation": ["2026-08-07T12:00:00Z", 140],
+  "BRAV.Stor.Inst.0.Top of Inactive": ["2026-08-07T12:00:00Z", 20],
+  "CHAR.Stor.Inst.0.Top of Flood": ["2026-08-07T12:00:00Z", 150],
+  "CHAR.Stor.Inst.0.Top of Conservation": ["2026-08-07T12:00:00Z", 110],
+  "CHAR.Stor.Inst.0.Top of Inactive": ["2026-08-07T12:00:00Z", 30],
+};
+
+const timeSeriesData = {
+  "ALFA.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [
+    "2026-08-07T12:00:00Z",
+    72,
+  ],
+  "BRAV.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [
+    "2026-08-07T12:00:00Z",
+    96,
+  ],
+  // -901 is rendered as a missing-storage segment.
+  "CHAR.Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev": [
+    "2026-08-07T12:00:00Z",
+    -901,
+  ],
+};
+
 <BasinPie
   projects={["ALFA", "BRAV", "CHAR"]}
   pool="conservation"

--- a/docs/src/pages/docs/plots/index.jsx
+++ b/docs/src/pages/docs/plots/index.jsx
@@ -27,6 +27,11 @@ function PlotsDocs() {
             CMWSPlot - A generic plot for displaying CWMS data
           </Link>
         </li>
+        <li>
+          <Link href={`${BASE_URL}#/docs/plots/basin-pie`}>
+            BasinPie - An interactive basin storage graphic
+          </Link>
+        </li>
       </ul>
       <br />
       ``

--- a/lib/components/data/helpers/__tests__/levels.test.ts
+++ b/lib/components/data/helpers/__tests__/levels.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchCdaLevelTimeSeries, fetchCdaLevelValues } from "../levels";
+
+const cdaParams = {
+  office: "SWT",
+  unit: "ac-ft",
+  interval: "1Hour",
+  begin: "2026-08-07T12:00:00Z",
+  end: "2026-08-07T13:00:00Z",
+  timezone: "UTC",
+};
+
+describe("level time-series helpers", () => {
+  it("uses the exact level time-series operation", async () => {
+    const levelsApi = {
+      getLevelsWithLevelIdTimeSeries: vi.fn().mockResolvedValue({
+        name: "KEYS.Stor.Inst.1Hour.0.Top of Conservation",
+        values: [[Date.UTC(2026, 7, 7, 13), 400983.849, 0]],
+      }),
+    };
+
+    await fetchCdaLevelTimeSeries({
+      cdaParams: {
+        ...cdaParams,
+        levelId: "KEYS.Stor.Inst.0.Top of Conservation",
+      },
+      levelsApi,
+    });
+
+    expect(levelsApi.getLevelsWithLevelIdTimeSeries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        levelId: "KEYS.Stor.Inst.0.Top of Conservation",
+        interval: "1Hour",
+      }),
+    );
+  });
+
+  it("keys latest values by the requested level id and reports progress", async () => {
+    const onProgress = vi.fn();
+    const levelsApi = {
+      getLevelsWithLevelIdTimeSeries: vi
+        .fn()
+        .mockResolvedValueOnce({
+          values: [
+            [1, 100, 0],
+            [2, 101, 0],
+          ],
+        })
+        .mockResolvedValueOnce({
+          values: [
+            [1, null, 0],
+            [2, 202, 0],
+          ],
+        }),
+    };
+
+    const result = await fetchCdaLevelValues({
+      levelIds: ["A.Stor.Inst.0.Top of Conservation", "B.Stor.Inst.0.Top of Flood"],
+      cdaParams,
+      levelsApi,
+      onProgress,
+    });
+
+    expect(result).toEqual({
+      "A.Stor.Inst.0.Top of Conservation": [2, 101, 0],
+      "B.Stor.Inst.0.Top of Flood": [2, 202, 0],
+    });
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2);
+  });
+});

--- a/lib/components/data/helpers/levels.ts
+++ b/lib/components/data/helpers/levels.ts
@@ -62,7 +62,13 @@ const fetchCdaLevelValues = async ({
     }),
   );
 
-  return Object.fromEntries(entries.filter((entry) => entry[1] !== undefined));
+  return entries.reduce<Record<string, (typeof entries)[number][1]>>(
+    (values, [levelId, entry]) => {
+      if (entry !== undefined) values[levelId] = entry;
+      return values;
+    },
+    {},
+  );
 };
 
 export { fetchCdaLevelTimeSeries, fetchCdaLevelValues };

--- a/lib/components/data/helpers/levels.ts
+++ b/lib/components/data/helpers/levels.ts
@@ -1,0 +1,69 @@
+import {
+  Configuration,
+  GetLevelsWithLevelIdTimeSeriesRequest,
+  LevelsApi,
+  TimeSeries,
+} from "cwmsjs";
+import { getLatestEntry } from "./cda";
+
+interface LevelTimeSeriesApi {
+  getLevelsWithLevelIdTimeSeries(
+    request: GetLevelsWithLevelIdTimeSeriesRequest,
+  ): Promise<TimeSeries>;
+}
+
+interface FetchCdaLevelTimeSeriesParams {
+  cdaParams: GetLevelsWithLevelIdTimeSeriesRequest;
+  cdaUrl?: string;
+  levelsApi?: LevelTimeSeriesApi;
+}
+
+interface FetchCdaLevelValuesParams {
+  levelIds: string[];
+  cdaParams: Omit<GetLevelsWithLevelIdTimeSeriesRequest, "levelId">;
+  cdaUrl?: string;
+  levelsApi?: LevelTimeSeriesApi;
+  onProgress?: (completed: number, total: number) => void;
+}
+
+const createLevelsApi = (cdaUrl?: string) =>
+  new LevelsApi(
+    new Configuration({
+      basePath: cdaUrl,
+      headers: { accept: "application/json;version=2" },
+    }),
+  );
+
+const fetchCdaLevelTimeSeries = ({
+  cdaParams,
+  cdaUrl,
+  levelsApi,
+}: FetchCdaLevelTimeSeriesParams) =>
+  (levelsApi ?? createLevelsApi(cdaUrl)).getLevelsWithLevelIdTimeSeries(cdaParams);
+
+const fetchCdaLevelValues = async ({
+  levelIds,
+  cdaParams,
+  cdaUrl,
+  levelsApi,
+  onProgress,
+}: FetchCdaLevelValuesParams) => {
+  const api = levelsApi ?? createLevelsApi(cdaUrl);
+  let completed = 0;
+  const entries = await Promise.all(
+    levelIds.map(async (levelId) => {
+      const timeSeries = await fetchCdaLevelTimeSeries({
+        cdaParams: { ...cdaParams, levelId },
+        levelsApi: api,
+      });
+      completed += 1;
+      onProgress?.(completed, levelIds.length);
+      return [levelId, getLatestEntry(timeSeries)] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries.filter((entry) => entry[1] !== undefined));
+};
+
+export { fetchCdaLevelTimeSeries, fetchCdaLevelValues };
+export type { FetchCdaLevelTimeSeriesParams, FetchCdaLevelValuesParams };

--- a/lib/components/data/hooks/useCdaLevels.ts
+++ b/lib/components/data/hooks/useCdaLevels.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryOptions } from "@tanstack/react-query";
 import { LevelsApi, GetLevelsWithLevelIdTimeSeriesRequest, TimeSeries } from "cwmsjs";
 import { useCdaConfig } from "../helpers/cda";
+import { fetchCdaLevelTimeSeries } from "../helpers/levels";
 
 interface UseCdaLevelsParams {
   cdaParams: GetLevelsWithLevelIdTimeSeriesRequest;
@@ -14,7 +15,7 @@ const useCdaLevels = ({ cdaParams, cdaUrl, queryOptions }: UseCdaLevelsParams) =
 
   return useQuery({
     queryKey: ["cda", "levels", ...Object.values(cdaParams)],
-    queryFn: async () => levelsApi.getLevelsWithLevelIdTimeSeries(cdaParams),
+    queryFn: async () => fetchCdaLevelTimeSeries({ cdaParams, levelsApi }),
     ...queryOptions,
   });
 };

--- a/lib/components/data/plots/BasinPie.jsx
+++ b/lib/components/data/plots/BasinPie.jsx
@@ -1,5 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
+import { useEffect, useMemo, useState } from "react";
+import { Configuration, LevelsApi, TimeSeriesApi } from "cwmsjs";
 import { Skeleton } from "@usace/groundwork";
+import { getLatestEntry } from "../helpers/cda";
+import { fetchCdaLevelValues } from "../helpers/levels";
+import useCdaUrl from "../utilities/useCdaUrl";
 import RadialFillChart from "./RadialFillChart";
 
 const DEFAULT_LEVEL_ID_SUFFIXES = {
@@ -16,6 +21,115 @@ const DEFAULT_TIME_SERIES_ID_SUFFIXES = {
 const entryValue = (entry) => {
   const value = Array.isArray(entry) ? entry[1] : entry;
   return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+const normalizeIds = (ids) => {
+  if (!ids) return [];
+  return (Array.isArray(ids) ? ids : [ids])
+    .map((id) => String(id).trim())
+    .filter(Boolean);
+};
+
+/**
+ * @param {object} options
+ * @param {string|string[]} [options.levelIds]
+ * @param {string|string[]} [options.tsids]
+ * @param {string} [options.office]
+ * @param {string} [options.begin]
+ * @param {string} [options.end]
+ * @param {string} [options.unit]
+ * @param {string} [options.interval]
+ * @param {string} [options.timezone]
+ * @param {boolean} [options.trim]
+ * @param {number} [options.pageSize]
+ * @param {string} [options.cdaUrl]
+ * @param {*} [options.levelsApi]
+ * @param {*} [options.timeSeriesApi]
+ * @param {(completed: number, total: number) => void} [options.onProgress]
+ */
+const loadBasinPieData = async ({
+  levelIds = [],
+  tsids = [],
+  office = undefined,
+  begin = undefined,
+  end = undefined,
+  unit = "ac-ft",
+  interval = "1Hour",
+  timezone = "UTC",
+  trim = true,
+  pageSize = undefined,
+  cdaUrl = undefined,
+  levelsApi = undefined,
+  timeSeriesApi = undefined,
+  onProgress = undefined,
+}) => {
+  const normalizedLevelIds = normalizeIds(levelIds);
+  const normalizedTsids = normalizeIds(tsids);
+  const total = normalizedLevelIds.length + normalizedTsids.length;
+
+  if (total > 0 && !office) {
+    throw new Error("You must specify a 3 letter ID for the office");
+  }
+
+  const requestEnd = end ?? new Date().toISOString();
+  const parsedEnd = new Date(requestEnd).getTime();
+  const requestBegin =
+    begin ??
+    new Date(
+      (Number.isFinite(parsedEnd) ? parsedEnd : Date.now()) - 3 * 60 * 60 * 1000,
+    ).toISOString();
+  const configuration = new Configuration({
+    ...(cdaUrl ? { basePath: cdaUrl } : {}),
+    headers: { accept: "application/json;version=2" },
+  });
+  const resolvedLevelsApi = levelsApi ?? new LevelsApi(configuration);
+  const resolvedTimeSeriesApi = timeSeriesApi ?? new TimeSeriesApi(configuration);
+  let levelCompleted = 0;
+  let timeSeriesCompleted = 0;
+  const reportProgress = () =>
+    onProgress?.(levelCompleted + timeSeriesCompleted, total);
+
+  const levelDataPromise = fetchCdaLevelValues({
+    levelIds: normalizedLevelIds,
+    cdaParams: {
+      office,
+      unit,
+      interval,
+      begin: requestBegin,
+      end: requestEnd,
+      timezone,
+    },
+    levelsApi: resolvedLevelsApi,
+    onProgress: (completed) => {
+      levelCompleted = completed;
+      reportProgress();
+    },
+  });
+  const tsDataPromise = Promise.all(
+    normalizedTsids.map(async (name) => {
+      try {
+        const result = await resolvedTimeSeriesApi.getTimeSeries({
+          name,
+          office,
+          unit,
+          begin: requestBegin,
+          end: requestEnd,
+          timezone,
+          trim,
+          pageSize,
+        });
+        return [name, getLatestEntry(result)];
+      } finally {
+        timeSeriesCompleted += 1;
+        reportProgress();
+      }
+    }),
+  ).then((entries) =>
+    Object.fromEntries(entries.filter((entry) => entry[1] !== undefined)),
+  );
+
+  const [levelData, tsData] = await Promise.all([levelDataPromise, tsDataPromise]);
+  return { levelData, tsData };
 };
 
 const createBasinPieModel = ({
@@ -78,11 +192,67 @@ const createBasinPieModel = ({
   return { segments, totalCapacity, totalStorage, percentFull };
 };
 
+/**
+ * @typedef {Object} BasinPieProps
+ * @property {string[]} [projects]
+ * @property {"conservation"|"flood"} [pool]
+ * @property {Record<string, number|Array<unknown>|null>} [levelData]
+ * @property {Record<string, number|Array<unknown>|null>} [tsData]
+ * @property {Record<string, number|Array<unknown>|null>} [timeSeriesData]
+ * @property {string|string[]} [levelIds]
+ * @property {string|string[]} [tsids]
+ * @property {string} [office]
+ * @property {string} [begin]
+ * @property {string} [end]
+ * @property {string} [unit]
+ * @property {string} [interval]
+ * @property {string} [timezone]
+ * @property {boolean} [trim]
+ * @property {number} [pageSize]
+ * @property {string} [cdaUrl]
+ * @property {{topOfFlood: string, topOfConservation: string, topOfInactive: string}} [levelIdSuffixes]
+ * @property {{flood: string, conservation: string}} [timeSeriesIdSuffixes]
+ * @property {string[]} [colors]
+ * @property {boolean} [isPending]
+ * @property {Error|string} [error]
+ * @property {number} [progress]
+ * @property {string} [asOf]
+ * @property {string} [title]
+ * @property {string} [caption]
+ * @property {(projectId: string) => void} [onProjectSelect]
+ * @property {number} [width]
+ * @property {number} [height]
+ * @property {number} [viewBoxWidth]
+ * @property {number} [viewBoxHeight]
+ * @property {number} [centerX]
+ * @property {number} [centerY]
+ * @property {number} [fontSize]
+ * @property {number} [strokeWidth]
+ * @property {number} [hoverOffset]
+ * @property {string} [ariaLabel]
+ * @property {string} [id]
+ * @property {string} [className]
+ * @property {import("react").CSSProperties} [style]
+ */
+
+/** @param {BasinPieProps} props */
 const BasinPie = ({
   projects = [],
   pool = "conservation",
   levelData,
+  tsData,
   timeSeriesData,
+  levelIds,
+  tsids,
+  office,
+  begin,
+  end,
+  unit = "ac-ft",
+  interval = "1Hour",
+  timezone = "UTC",
+  trim = true,
+  pageSize,
+  cdaUrl,
   levelIdSuffixes = DEFAULT_LEVEL_ID_SUFFIXES,
   timeSeriesIdSuffixes = DEFAULT_TIME_SERIES_ID_SUFFIXES,
   colors,
@@ -99,7 +269,109 @@ const BasinPie = ({
   ariaLabel = `${pool === "flood" ? "Flood" : "Conservation"} pool storage by project`,
   ...chartProps
 }) => {
-  if (isPending) {
+  const providedCdaUrl = useCdaUrl();
+  const resolvedCdaUrl = cdaUrl ?? providedCdaUrl;
+  const levelIdsKey = JSON.stringify(normalizeIds(levelIds));
+  const tsidsKey = JSON.stringify(normalizeIds(tsids));
+  const normalizedLevelIds = useMemo(() => JSON.parse(levelIdsKey), [levelIdsKey]);
+  const normalizedTsids = useMemo(() => JSON.parse(tsidsKey), [tsidsKey]);
+  const directTsData = tsData !== undefined ? tsData : timeSeriesData;
+  const needsLevelFetch = levelData === undefined && normalizedLevelIds.length > 0;
+  const needsTimeSeriesFetch = directTsData === undefined && normalizedTsids.length > 0;
+  const requiresOffice = needsLevelFetch || needsTimeSeriesFetch;
+  const isOfficeMissing = requiresOffice && !office;
+  const [fetchedLevelData, setFetchedLevelData] = useState();
+  const [fetchedTsData, setFetchedTsData] = useState();
+  const [fetchError, setFetchError] = useState(null);
+  const [fetchProgress, setFetchProgress] = useState(0);
+  const [isFetching, setIsFetching] = useState(false);
+
+  useEffect(() => {
+    if (!requiresOffice || isOfficeMissing) {
+      setIsFetching(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsFetching(true);
+    setFetchError(null);
+    setFetchProgress(0);
+    if (needsLevelFetch) setFetchedLevelData(undefined);
+    if (needsTimeSeriesFetch) setFetchedTsData(undefined);
+
+    loadBasinPieData({
+      levelIds: needsLevelFetch ? normalizedLevelIds : [],
+      tsids: needsTimeSeriesFetch ? normalizedTsids : [],
+      office,
+      begin,
+      end,
+      unit,
+      interval,
+      timezone,
+      trim,
+      pageSize,
+      cdaUrl: resolvedCdaUrl,
+      onProgress: (completed, total) => {
+        if (!cancelled && total > 0) {
+          setFetchProgress(Math.round((completed / total) * 100));
+        }
+      },
+    })
+      .then((result) => {
+        if (cancelled) return;
+        if (needsLevelFetch) setFetchedLevelData(result.levelData);
+        if (needsTimeSeriesFetch) setFetchedTsData(result.tsData);
+      })
+      .catch((caughtError) => {
+        if (!cancelled) setFetchError(caughtError);
+      })
+      .finally(() => {
+        if (!cancelled) setIsFetching(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    begin,
+    end,
+    interval,
+    needsLevelFetch,
+    needsTimeSeriesFetch,
+    normalizedLevelIds,
+    normalizedTsids,
+    office,
+    isOfficeMissing,
+    pageSize,
+    requiresOffice,
+    resolvedCdaUrl,
+    timezone,
+    trim,
+    unit,
+  ]);
+
+  const resolvedLevelData = levelData !== undefined ? levelData : fetchedLevelData;
+  const resolvedTsData = directTsData !== undefined ? directTsData : fetchedTsData;
+  const resolvedError =
+    error ||
+    (isOfficeMissing
+      ? new Error("You must specify a 3 letter ID for the office")
+      : null) ||
+    fetchError;
+  const resolvedPending =
+    isPending ||
+    isFetching ||
+    (needsLevelFetch && fetchedLevelData === undefined && !resolvedError) ||
+    (needsTimeSeriesFetch && fetchedTsData === undefined && !resolvedError);
+  const resolvedProgress = requiresOffice ? fetchProgress : progress;
+
+  if (resolvedError) {
+    return (
+      <div role="alert">Error: {resolvedError?.message || String(resolvedError)}</div>
+    );
+  }
+
+  if (resolvedPending) {
     return (
       <Skeleton
         type="card"
@@ -113,16 +385,15 @@ const BasinPie = ({
         <div role="status" aria-live="polite">
           {Math.min(
             100,
-            Math.max(0, Number.isFinite(progress) ? Math.round(progress) : 0),
+            Math.max(
+              0,
+              Number.isFinite(resolvedProgress) ? Math.round(resolvedProgress) : 0,
+            ),
           )}
           %
         </div>
       </Skeleton>
     );
-  }
-
-  if (error) {
-    return <div role="alert">Error: {error?.message || String(error)}</div>;
   }
 
   if (pool !== "conservation" && pool !== "flood") {
@@ -132,8 +403,8 @@ const BasinPie = ({
   const model = createBasinPieModel({
     projects,
     pool,
-    levelData,
-    timeSeriesData,
+    levelData: resolvedLevelData,
+    timeSeriesData: resolvedTsData,
     levelIdSuffixes,
     timeSeriesIdSuffixes,
     colors,
@@ -167,5 +438,7 @@ export {
   DEFAULT_TIME_SERIES_ID_SUFFIXES,
   createBasinPieModel,
   entryValue,
+  loadBasinPieData,
+  normalizeIds,
 };
 export default BasinPie;

--- a/lib/components/data/plots/BasinPie.jsx
+++ b/lib/components/data/plots/BasinPie.jsx
@@ -1,0 +1,173 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Skeleton } from "@usace/groundwork";
+import RadialFillChart from "./RadialFillChart";
+
+const DEFAULT_LEVEL_ID_SUFFIXES = {
+  topOfFlood: ".Stor.Inst.0.Top of Flood",
+  topOfConservation: ".Stor.Inst.0.Top of Conservation",
+  topOfInactive: ".Stor.Inst.0.Top of Inactive",
+};
+
+const DEFAULT_TIME_SERIES_ID_SUFFIXES = {
+  flood: ".Stor-Flood Pool.Inst.1Hour.0.Ccp-Rev",
+  conservation: ".Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev",
+};
+
+const MISSING_VALUE = -901;
+
+const entryValue = (entry) => {
+  const value = Array.isArray(entry) ? entry[1] : entry;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+const createBasinPieModel = ({
+  projects,
+  pool,
+  levelData,
+  timeSeriesData,
+  levelIdSuffixes = DEFAULT_LEVEL_ID_SUFFIXES,
+  timeSeriesIdSuffixes = DEFAULT_TIME_SERIES_ID_SUFFIXES,
+  colors,
+}) => {
+  const segments = [];
+  let totalCapacity = 0;
+  let totalStorage = 0;
+
+  projects.forEach((project, index) => {
+    const topOfFlood = entryValue(
+      levelData?.[`${project}${levelIdSuffixes.topOfFlood}`],
+    );
+    const topOfConservation = entryValue(
+      levelData?.[`${project}${levelIdSuffixes.topOfConservation}`],
+    );
+    const topOfInactive = entryValue(
+      levelData?.[`${project}${levelIdSuffixes.topOfInactive}`],
+    );
+    const capacity =
+      pool === "flood"
+        ? topOfFlood !== null && topOfConservation !== null
+          ? topOfFlood - topOfConservation
+          : null
+        : topOfConservation !== null && topOfInactive !== null
+          ? topOfConservation - topOfInactive
+          : null;
+
+    if (!Number.isFinite(capacity) || capacity <= 0) return;
+
+    const storage = entryValue(
+      timeSeriesData?.[
+        `${project}${pool === "flood" ? timeSeriesIdSuffixes.flood : timeSeriesIdSuffixes.conservation}`
+      ],
+    );
+    const missing = storage === null || storage === MISSING_VALUE;
+
+    totalCapacity += capacity;
+    if (!missing && storage > 0) totalStorage += storage;
+    segments.push({
+      id: project,
+      label: project,
+      weight: capacity,
+      fillRatio: missing ? null : storage / capacity,
+      color: colors?.[index % colors.length],
+    });
+  });
+
+  const percentFull =
+    totalCapacity > 0
+      ? Math.min(100, Math.max(0, Math.round((totalStorage / totalCapacity) * 100)))
+      : 0;
+
+  return { segments, totalCapacity, totalStorage, percentFull };
+};
+
+const BasinPie = ({
+  projects = [],
+  pool = "conservation",
+  levelData,
+  timeSeriesData,
+  levelIdSuffixes = DEFAULT_LEVEL_ID_SUFFIXES,
+  timeSeriesIdSuffixes = DEFAULT_TIME_SERIES_ID_SUFFIXES,
+  colors,
+  isPending = false,
+  error,
+  progress = 0,
+  asOf,
+  title,
+  caption,
+  onProjectSelect,
+  width = 480,
+  height = 480,
+  viewBoxHeight = height + 120,
+  ariaLabel = `${pool === "flood" ? "Flood" : "Conservation"} pool storage by project`,
+  ...chartProps
+}) => {
+  if (isPending) {
+    return (
+      <Skeleton
+        type="card"
+        style={{
+          borderRadius: width,
+          height: `${height}px`,
+          width: `${viewBoxHeight}px`,
+        }}
+        className={chartProps.className}
+      >
+        <div role="status" aria-live="polite">
+          {Math.min(
+            100,
+            Math.max(0, Number.isFinite(progress) ? Math.round(progress) : 0),
+          )}
+          %
+        </div>
+      </Skeleton>
+    );
+  }
+
+  if (error) {
+    return <div role="alert">Error: {error?.message || String(error)}</div>;
+  }
+
+  if (pool !== "conservation" && pool !== "flood") {
+    return <div role="alert">Pool must be either conservation or flood.</div>;
+  }
+
+  const model = createBasinPieModel({
+    projects,
+    pool,
+    levelData,
+    timeSeriesData,
+    levelIdSuffixes,
+    timeSeriesIdSuffixes,
+    colors,
+  });
+  const defaultTitle = `THE FULL PIE IS ${Math.trunc(model.totalStorage).toLocaleString()} ACRE-FEET OR ${model.percentFull}%`;
+  const defaultCaption = asOf ? `IMAGE DATE: ${asOf}` : undefined;
+
+  return (
+    <RadialFillChart
+      {...chartProps}
+      width={width}
+      height={height}
+      viewBoxHeight={viewBoxHeight}
+      segments={model.segments}
+      title={title ?? defaultTitle}
+      caption={caption ?? defaultCaption}
+      ariaLabel={ariaLabel}
+      emptyMessage="No usable basin storage capacity data is available."
+      onSegmentSelect={
+        typeof onProjectSelect === "function"
+          ? (segment) => onProjectSelect(segment.id)
+          : undefined
+      }
+    />
+  );
+};
+
+export {
+  BasinPie,
+  DEFAULT_LEVEL_ID_SUFFIXES,
+  DEFAULT_TIME_SERIES_ID_SUFFIXES,
+  createBasinPieModel,
+  entryValue,
+};
+export default BasinPie;

--- a/lib/components/data/plots/BasinPie.jsx
+++ b/lib/components/data/plots/BasinPie.jsx
@@ -13,8 +13,6 @@ const DEFAULT_TIME_SERIES_ID_SUFFIXES = {
   conservation: ".Stor-Conservation Pool.Inst.1Hour.0.Ccp-Rev",
 };
 
-const MISSING_VALUE = -901;
-
 const entryValue = (entry) => {
   const value = Array.isArray(entry) ? entry[1] : entry;
   return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -59,7 +57,7 @@ const createBasinPieModel = ({
         `${project}${pool === "flood" ? timeSeriesIdSuffixes.flood : timeSeriesIdSuffixes.conservation}`
       ],
     );
-    const missing = storage === null || storage === MISSING_VALUE;
+    const missing = storage === null;
 
     totalCapacity += capacity;
     if (!missing && storage > 0) totalStorage += storage;

--- a/lib/components/data/plots/RadialFillChart.jsx
+++ b/lib/components/data/plots/RadialFillChart.jsx
@@ -1,0 +1,280 @@
+/* eslint-disable react-refresh/only-export-components */
+import { useState } from "react";
+
+const DEFAULT_COLORS = [
+  "rgb(197, 92, 230)",
+  "rgb(244, 217, 102)",
+  "rgb(38, 192, 163)",
+  "rgb(77, 237, 69)",
+  "rgb(66, 91, 214)",
+  "rgb(11, 170, 227)",
+  "rgb(255, 192, 0)",
+  "rgb(29, 131, 151)",
+];
+
+const polarPoint = (centerX, centerY, radius, angle) => {
+  const radians = (angle * Math.PI) / 180;
+  return {
+    x: centerX + radius * Math.sin(radians),
+    y: centerY - radius * Math.cos(radians),
+  };
+};
+
+const radialSegmentPath = (centerX, centerY, radius, startAngle, endAngle) => {
+  if (!Number.isFinite(radius) || radius <= 0) return "";
+
+  const sweep = Math.max(0, endAngle - startAngle);
+  const start = polarPoint(centerX, centerY, radius, startAngle);
+  const end = polarPoint(centerX, centerY, radius, endAngle);
+
+  if (sweep >= 359.999) {
+    const opposite = polarPoint(centerX, centerY, radius, startAngle + 180);
+    return [
+      `M ${centerX} ${centerY}`,
+      `L ${start.x} ${start.y}`,
+      `A ${radius} ${radius} 0 1 1 ${opposite.x} ${opposite.y}`,
+      `A ${radius} ${radius} 0 1 1 ${start.x} ${start.y}`,
+      "Z",
+    ].join(" ");
+  }
+
+  return [
+    `M ${centerX} ${centerY}`,
+    `L ${start.x} ${start.y}`,
+    `A ${radius} ${radius} 0 ${sweep > 180 ? 1 : 0} 1 ${end.x} ${end.y}`,
+    "Z",
+  ].join(" ");
+};
+
+const normalizeSegments = (segments) =>
+  segments
+    .filter((segment) => Number.isFinite(segment?.weight) && segment.weight > 0)
+    .map((segment, index) => ({
+      ...segment,
+      id: String(segment.id),
+      label: String(segment.label ?? segment.id),
+      color: segment.color || DEFAULT_COLORS[index % DEFAULT_COLORS.length],
+      fillRatio:
+        segment.fillRatio === null || !Number.isFinite(segment.fillRatio)
+          ? null
+          : Math.min(1, Math.max(0, segment.fillRatio)),
+    }));
+
+const RadialFillChart = ({
+  segments = [],
+  title,
+  caption,
+  id,
+  className = "",
+  width = 480,
+  height = 480,
+  viewBoxWidth = width + 120,
+  viewBoxHeight = height + 120,
+  centerX = viewBoxWidth / 2,
+  centerY = viewBoxHeight / 2,
+  radius = Math.min(width, height) / 2,
+  fontSize = 16,
+  strokeWidth = 1,
+  hoverOffset = 20,
+  ariaLabel = "Radial fill chart",
+  emptyMessage = "No chart data is available.",
+  onSegmentSelect,
+  style,
+}) => {
+  const [activeIndex, setActiveIndex] = useState(null);
+  const normalizedSegments = normalizeSegments(segments);
+  const totalWeight = normalizedSegments.reduce(
+    (total, segment) => total + segment.weight,
+    0,
+  );
+
+  if (normalizedSegments.length === 0 || totalWeight <= 0) {
+    return (
+      <div id={id} className={className} style={style} role="status">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  const chartSegments = normalizedSegments.reduce((laidOut, segment) => {
+    const angle = (segment.weight / totalWeight) * 360;
+    const startAngle = laidOut.at(-1)?.endAngle ?? 0;
+    return [...laidOut, { ...segment, startAngle, endAngle: startAngle + angle }];
+  }, []);
+  const interactive = typeof onSegmentSelect === "function";
+
+  return (
+    <svg
+      id={id}
+      className={className}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
+      preserveAspectRatio="xMidYMid meet"
+      role="img"
+      aria-label={ariaLabel}
+      style={{ maxWidth: "100%", height: "auto", ...style }}
+    >
+      <title>{ariaLabel}</title>
+      {title ? (
+        <text
+          x={viewBoxWidth / 2}
+          y={fontSize * 1.5}
+          textAnchor="middle"
+          fontFamily="Arial, sans-serif"
+          fontSize={fontSize}
+          fontWeight="bold"
+        >
+          {title}
+        </text>
+      ) : null}
+
+      <g data-chart-layer="segments">
+        {chartSegments.map((segment, index) => {
+          const active = activeIndex === index;
+          const middleAngle =
+            segment.startAngle + (segment.endAngle - segment.startAngle) / 2;
+          const middleRadians = (middleAngle * Math.PI) / 180;
+          const offsetX = active ? hoverOffset * Math.sin(middleRadians) : 0;
+          const offsetY = active ? -hoverOffset * Math.cos(middleRadians) : 0;
+          const labelRadius =
+            segment.endAngle - segment.startAngle < 10 ? radius * 1.135 : radius * 1.12;
+          const labelPoint = polarPoint(centerX, centerY, labelRadius, middleAngle);
+          const percentage =
+            segment.fillRatio === null ? null : Math.round(segment.fillRatio * 100);
+          const accessibleLabel =
+            percentage === null
+              ? `${segment.label}: data missing`
+              : `${segment.label}: ${percentage}% full`;
+          const selectSegment = () => {
+            if (interactive) onSegmentSelect(segment);
+          };
+
+          return (
+            <g
+              key={`${segment.id}-${index}`}
+              data-segment-id={segment.id}
+              role={interactive ? "button" : "img"}
+              tabIndex={interactive ? 0 : undefined}
+              aria-label={accessibleLabel}
+              onMouseEnter={() => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
+              onFocus={() => setActiveIndex(index)}
+              onBlur={() => setActiveIndex(null)}
+              onClick={selectSegment}
+              onKeyDown={(event) => {
+                if (interactive && (event.key === "Enter" || event.key === " ")) {
+                  event.preventDefault();
+                  selectSegment();
+                }
+              }}
+              style={interactive ? { cursor: "pointer", outline: "none" } : undefined}
+            >
+              <g transform={`translate(${offsetX} ${offsetY})`}>
+                <path
+                  d={radialSegmentPath(
+                    centerX,
+                    centerY,
+                    radius - strokeWidth * 2,
+                    segment.startAngle,
+                    segment.endAngle,
+                  )}
+                  fill="none"
+                  stroke="black"
+                  strokeWidth={active ? Math.max(3, strokeWidth) : strokeWidth}
+                />
+                {segment.fillRatio !== null && segment.fillRatio > 0 ? (
+                  <path
+                    d={radialSegmentPath(
+                      centerX,
+                      centerY,
+                      (radius - strokeWidth * 2) * segment.fillRatio,
+                      segment.startAngle,
+                      segment.endAngle,
+                    )}
+                    fill={segment.color}
+                    stroke="black"
+                    strokeWidth={strokeWidth}
+                  />
+                ) : null}
+              </g>
+              <text
+                x={labelPoint.x}
+                y={labelPoint.y}
+                dy="0.35em"
+                textAnchor="middle"
+                fill={percentage === null ? "#b91c1c" : "black"}
+                fontFamily="Arial, sans-serif"
+                fontSize={fontSize}
+                opacity={activeIndex !== null && !active ? 0.1 : 1}
+                aria-hidden="true"
+              >
+                {percentage === null
+                  ? `${segment.label} Missing ⚠`
+                  : `${segment.label} ${percentage}%`}
+              </text>
+            </g>
+          );
+        })}
+      </g>
+
+      <g data-chart-layer="reference-marks" aria-hidden="true">
+        {[1, 0.75, 0.5, 0.25].map((percentage) => (
+          <g key={percentage}>
+            <text
+              x={centerX - 15}
+              y={centerY - radius * percentage - strokeWidth * 2}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontFamily="Arial, sans-serif"
+              fontSize={fontSize}
+              stroke="white"
+              strokeWidth={Math.max(3, fontSize / 4)}
+              paintOrder="stroke"
+            >
+              {percentage * 100}%
+            </text>
+            {percentage !== 1 ? (
+              <>
+                <circle
+                  cx={centerX}
+                  cy={centerY}
+                  r={radius * percentage}
+                  stroke="white"
+                  strokeWidth={Math.max(3, strokeWidth + 2)}
+                  strokeDasharray="16 16"
+                  fill="none"
+                />
+                <circle
+                  cx={centerX}
+                  cy={centerY}
+                  r={radius * percentage}
+                  stroke="black"
+                  strokeWidth={strokeWidth}
+                  strokeDasharray="16 16"
+                  fill="none"
+                />
+              </>
+            ) : null}
+          </g>
+        ))}
+      </g>
+
+      {caption ? (
+        <text
+          x={viewBoxWidth / 2}
+          y={viewBoxHeight - fontSize / 2}
+          textAnchor="middle"
+          fontFamily="Arial, sans-serif"
+          fontSize={fontSize}
+          fontWeight="bold"
+        >
+          {caption}
+        </text>
+      ) : null}
+    </svg>
+  );
+};
+
+export { RadialFillChart, normalizeSegments, radialSegmentPath };
+export default RadialFillChart;

--- a/lib/components/data/plots/RadialFillChart.jsx
+++ b/lib/components/data/plots/RadialFillChart.jsx
@@ -20,6 +20,25 @@ const polarPoint = (centerX, centerY, radius, angle) => {
   };
 };
 
+const TEXT_WIDTH_FACTOR = 0.62;
+
+const estimatedTextWidth = (text, fontSize) =>
+  String(text).length * fontSize * TEXT_WIDTH_FACTOR;
+
+const fittedFontSize = (text, preferredFontSize, availableWidth) => {
+  const estimatedWidth = estimatedTextWidth(text, preferredFontSize);
+  return estimatedWidth > availableWidth && estimatedWidth > 0
+    ? (preferredFontSize * availableWidth) / estimatedWidth
+    : preferredFontSize;
+};
+
+const clampedTextX = (x, text, fontSize, viewBoxWidth, padding = fontSize / 2) => {
+  const halfWidth = estimatedTextWidth(text, fontSize) / 2;
+  const minimum = padding + halfWidth;
+  const maximum = viewBoxWidth - padding - halfWidth;
+  return minimum > maximum ? viewBoxWidth / 2 : Math.min(maximum, Math.max(minimum, x));
+};
+
 const radialSegmentPath = (centerX, centerY, radius, startAngle, endAngle) => {
   if (!Number.isFinite(radius) || radius <= 0) return "";
 
@@ -59,6 +78,72 @@ const normalizeSegments = (segments) =>
           ? null
           : Math.min(1, Math.max(0, segment.fillRatio)),
     }));
+
+const layoutSegmentLabels = (
+  segments,
+  { centerX, centerY, radius, fontSize, viewBoxWidth, viewBoxHeight, title, caption },
+) => {
+  const labels = segments.map((segment, index) => {
+    const middleAngle =
+      segment.startAngle + (segment.endAngle - segment.startAngle) / 2;
+    const middleRadians = (middleAngle * Math.PI) / 180;
+    const labelRadius =
+      segment.endAngle - segment.startAngle < 10 ? radius * 1.135 : radius * 1.12;
+    const labelPoint = polarPoint(centerX, centerY, labelRadius, middleAngle);
+    const percentage =
+      segment.fillRatio === null ? null : Math.round(segment.fillRatio * 100);
+    const visibleLabel =
+      percentage === null
+        ? `${segment.label} Missing ⚠`
+        : `${segment.label} ${percentage}%`;
+    const labelFontSize = fittedFontSize(visibleLabel, fontSize, viewBoxWidth * 0.4);
+
+    return {
+      index,
+      segment,
+      middleRadians,
+      percentage,
+      visibleLabel,
+      labelFontSize,
+      labelX: clampedTextX(labelPoint.x, visibleLabel, labelFontSize, viewBoxWidth),
+      labelY: labelPoint.y,
+      side: Math.sin(middleRadians) < 0 ? "left" : "right",
+    };
+  });
+
+  const topLimit = title ? fontSize * 3 : fontSize;
+  const bottomLimit = caption
+    ? viewBoxHeight - fontSize * 2.25
+    : viewBoxHeight - fontSize;
+
+  ["left", "right"].forEach((side) => {
+    const sideLabels = labels
+      .filter((label) => label.side === side)
+      .sort((a, b) => a.labelY - b.labelY);
+
+    sideLabels.forEach((label, index) => {
+      if (index === 0) {
+        label.labelY = Math.max(topLimit, label.labelY);
+        return;
+      }
+      const previous = sideLabels[index - 1];
+      const gap = Math.max(previous.labelFontSize, label.labelFontSize) * 1.25;
+      label.labelY = Math.max(label.labelY, previous.labelY + gap);
+    });
+
+    if (sideLabels.at(-1)?.labelY > bottomLimit) {
+      sideLabels.at(-1).labelY = bottomLimit;
+      for (let index = sideLabels.length - 2; index >= 0; index -= 1) {
+        const label = sideLabels[index];
+        const next = sideLabels[index + 1];
+        const gap = Math.max(label.labelFontSize, next.labelFontSize) * 1.25;
+        label.labelY = Math.min(label.labelY, next.labelY - gap);
+      }
+    }
+  });
+
+  return labels.sort((a, b) => a.index - b.index);
+};
 
 const RadialFillChart = ({
   segments = [],
@@ -101,6 +186,16 @@ const RadialFillChart = ({
     const startAngle = laidOut.at(-1)?.endAngle ?? 0;
     return [...laidOut, { ...segment, startAngle, endAngle: startAngle + angle }];
   }, []);
+  const labelLayouts = layoutSegmentLabels(chartSegments, {
+    centerX,
+    centerY,
+    radius,
+    fontSize,
+    viewBoxWidth,
+    viewBoxHeight,
+    title,
+    caption,
+  });
   const interactive = typeof onSegmentSelect === "function";
 
   return (
@@ -122,7 +217,7 @@ const RadialFillChart = ({
           y={fontSize * 1.5}
           textAnchor="middle"
           fontFamily="Arial, sans-serif"
-          fontSize={fontSize}
+          fontSize={fittedFontSize(title, fontSize, viewBoxWidth - fontSize * 2)}
           fontWeight="bold"
         >
           {title}
@@ -130,22 +225,15 @@ const RadialFillChart = ({
       ) : null}
 
       <g data-chart-layer="segments">
-        {chartSegments.map((segment, index) => {
+        {labelLayouts.map((layout, index) => {
+          const { segment } = layout;
           const active = activeIndex === index;
-          const middleAngle =
-            segment.startAngle + (segment.endAngle - segment.startAngle) / 2;
-          const middleRadians = (middleAngle * Math.PI) / 180;
-          const offsetX = active ? hoverOffset * Math.sin(middleRadians) : 0;
-          const offsetY = active ? -hoverOffset * Math.cos(middleRadians) : 0;
-          const labelRadius =
-            segment.endAngle - segment.startAngle < 10 ? radius * 1.135 : radius * 1.12;
-          const labelPoint = polarPoint(centerX, centerY, labelRadius, middleAngle);
-          const percentage =
-            segment.fillRatio === null ? null : Math.round(segment.fillRatio * 100);
+          const offsetX = active ? hoverOffset * Math.sin(layout.middleRadians) : 0;
+          const offsetY = active ? -hoverOffset * Math.cos(layout.middleRadians) : 0;
           const accessibleLabel =
-            percentage === null
+            layout.percentage === null
               ? `${segment.label}: data missing`
-              : `${segment.label}: ${percentage}% full`;
+              : `${segment.label}: ${layout.percentage}% full`;
           const selectSegment = () => {
             if (interactive) onSegmentSelect(segment);
           };
@@ -199,19 +287,17 @@ const RadialFillChart = ({
                 ) : null}
               </g>
               <text
-                x={labelPoint.x}
-                y={labelPoint.y}
+                x={layout.labelX}
+                y={layout.labelY}
                 dy="0.35em"
                 textAnchor="middle"
-                fill={percentage === null ? "#b91c1c" : "black"}
+                fill={layout.percentage === null ? "#b91c1c" : "black"}
                 fontFamily="Arial, sans-serif"
-                fontSize={fontSize}
+                fontSize={layout.labelFontSize}
                 opacity={activeIndex !== null && !active ? 0.1 : 1}
                 aria-hidden="true"
               >
-                {percentage === null
-                  ? `${segment.label} Missing ⚠`
-                  : `${segment.label} ${percentage}%`}
+                {layout.visibleLabel}
               </text>
             </g>
           );
@@ -222,7 +308,7 @@ const RadialFillChart = ({
         {[1, 0.75, 0.5, 0.25].map((percentage) => (
           <g key={percentage}>
             <text
-              x={centerX - 15}
+              x={centerX - Math.max(15, fontSize * 3.25)}
               y={centerY - radius * percentage - strokeWidth * 2}
               textAnchor="middle"
               dominantBaseline="middle"
@@ -266,7 +352,7 @@ const RadialFillChart = ({
           y={viewBoxHeight - fontSize / 2}
           textAnchor="middle"
           fontFamily="Arial, sans-serif"
-          fontSize={fontSize}
+          fontSize={fittedFontSize(caption, fontSize, viewBoxWidth - fontSize * 2)}
           fontWeight="bold"
         >
           {caption}
@@ -276,5 +362,13 @@ const RadialFillChart = ({
   );
 };
 
-export { RadialFillChart, normalizeSegments, radialSegmentPath };
+export {
+  RadialFillChart,
+  clampedTextX,
+  estimatedTextWidth,
+  fittedFontSize,
+  layoutSegmentLabels,
+  normalizeSegments,
+  radialSegmentPath,
+};
 export default RadialFillChart;

--- a/lib/components/data/plots/__tests__/BasinPie.test.jsx
+++ b/lib/components/data/plots/__tests__/BasinPie.test.jsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import BasinPie, {
+  DEFAULT_LEVEL_ID_SUFFIXES,
+  DEFAULT_TIME_SERIES_ID_SUFFIXES,
+  createBasinPieModel,
+} from "../BasinPie";
+
+const levelData = {
+  [`A${DEFAULT_LEVEL_ID_SUFFIXES.topOfFlood}`]: [0, 200],
+  [`A${DEFAULT_LEVEL_ID_SUFFIXES.topOfConservation}`]: [0, 150],
+  [`A${DEFAULT_LEVEL_ID_SUFFIXES.topOfInactive}`]: [0, 50],
+  [`B${DEFAULT_LEVEL_ID_SUFFIXES.topOfFlood}`]: [0, 160],
+  [`B${DEFAULT_LEVEL_ID_SUFFIXES.topOfConservation}`]: [0, 120],
+  [`B${DEFAULT_LEVEL_ID_SUFFIXES.topOfInactive}`]: [0, 20],
+};
+
+describe("BasinPie", () => {
+  it("builds conservation and flood models", () => {
+    const conservation = createBasinPieModel({
+      projects: ["A", "B"],
+      pool: "conservation",
+      levelData,
+      timeSeriesData: {
+        [`A${DEFAULT_TIME_SERIES_ID_SUFFIXES.conservation}`]: [0, 50],
+        [`B${DEFAULT_TIME_SERIES_ID_SUFFIXES.conservation}`]: [0, 100],
+      },
+    });
+    expect(
+      conservation.segments.map(({ weight, fillRatio }) => ({ weight, fillRatio })),
+    ).toEqual([
+      { weight: 100, fillRatio: 0.5 },
+      { weight: 100, fillRatio: 1 },
+    ]);
+    expect(conservation.percentFull).toBe(75);
+
+    const flood = createBasinPieModel({
+      projects: ["A", "B"],
+      pool: "flood",
+      levelData,
+      timeSeriesData: {
+        [`A${DEFAULT_TIME_SERIES_ID_SUFFIXES.flood}`]: [0, 25],
+        [`B${DEFAULT_TIME_SERIES_ID_SUFFIXES.flood}`]: [0, 10],
+      },
+    });
+    expect(
+      flood.segments.map(({ weight, fillRatio }) => ({ weight, fillRatio })),
+    ).toEqual([
+      { weight: 50, fillRatio: 0.5 },
+      { weight: 40, fillRatio: 0.25 },
+    ]);
+  });
+
+  it("marks missing storage and skips missing capacity without throwing", () => {
+    const model = createBasinPieModel({
+      projects: ["A", "B", "MISSING"],
+      pool: "conservation",
+      levelData,
+      timeSeriesData: {
+        [`A${DEFAULT_TIME_SERIES_ID_SUFFIXES.conservation}`]: [0, -901],
+      },
+    });
+    expect(model.segments).toHaveLength(2);
+    expect(model.segments.every((segment) => segment.fillRatio === null)).toBe(true);
+  });
+
+  it("supports suffix overrides, loading, errors, and project selection", () => {
+    const suffixes = {
+      topOfFlood: ".tf",
+      topOfConservation: ".tc",
+      topOfInactive: ".ti",
+    };
+    const series = { flood: ".f", conservation: ".c" };
+    const onProjectSelect = vi.fn();
+    const { rerender } = render(
+      <BasinPie
+        projects={["X"]}
+        levelData={{ "X.tc": [0, 100], "X.ti": [0, 0], "X.tf": [0, 200] }}
+        timeSeriesData={{ "X.c": [0, 40] }}
+        levelIdSuffixes={suffixes}
+        timeSeriesIdSuffixes={series}
+        onProjectSelect={onProjectSelect}
+        asOf="2026-08-07T12"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "X: 40% full" }));
+    expect(onProjectSelect).toHaveBeenCalledWith("X");
+    expect(screen.getByText("IMAGE DATE: 2026-08-07T12")).toBeTruthy();
+
+    rerender(<BasinPie projects={["X"]} isPending progress={42.4} />);
+    expect(screen.getByRole("status").textContent).toBe("42%");
+    rerender(<BasinPie projects={["X"]} error={new Error("failed")} />);
+    expect(screen.getByRole("alert").textContent).toContain("failed");
+  });
+});

--- a/lib/components/data/plots/__tests__/BasinPie.test.jsx
+++ b/lib/components/data/plots/__tests__/BasinPie.test.jsx
@@ -56,9 +56,7 @@ describe("BasinPie", () => {
       projects: ["A", "B", "MISSING"],
       pool: "conservation",
       levelData,
-      timeSeriesData: {
-        [`A${DEFAULT_TIME_SERIES_ID_SUFFIXES.conservation}`]: [0, -901],
-      },
+      timeSeriesData: {},
     });
     expect(model.segments).toHaveLength(2);
     expect(model.segments.every((segment) => segment.fillRatio === null)).toBe(true);

--- a/lib/components/data/plots/__tests__/BasinPie.test.jsx
+++ b/lib/components/data/plots/__tests__/BasinPie.test.jsx
@@ -4,6 +4,7 @@ import BasinPie, {
   DEFAULT_LEVEL_ID_SUFFIXES,
   DEFAULT_TIME_SERIES_ID_SUFFIXES,
   createBasinPieModel,
+  loadBasinPieData,
 } from "../BasinPie";
 
 const levelData = {
@@ -62,6 +63,56 @@ describe("BasinPie", () => {
     expect(model.segments.every((segment) => segment.fillRatio === null)).toBe(true);
   });
 
+  it("loads levelIds and tsids with the office-scoped CDA time-series APIs", async () => {
+    const onProgress = vi.fn();
+    const levelsApi = {
+      getLevelsWithLevelIdTimeSeries: vi.fn().mockResolvedValue({
+        values: [
+          [1, 99, 0],
+          [2, 100, 0],
+        ],
+      }),
+    };
+    const timeSeriesApi = {
+      getTimeSeries: vi.fn().mockResolvedValue({
+        values: [
+          [1, null, 0],
+          [2, 50, 0],
+        ],
+      }),
+    };
+
+    const result = await loadBasinPieData({
+      levelIds: ["A.level"],
+      tsids: ["A.timeseries"],
+      office: "SWT",
+      begin: "2026-08-07T11:00:00Z",
+      end: "2026-08-07T12:00:00Z",
+      levelsApi,
+      timeSeriesApi,
+      onProgress,
+    });
+
+    expect(levelsApi.getLevelsWithLevelIdTimeSeries).toHaveBeenCalledWith(
+      expect.objectContaining({ levelId: "A.level", office: "SWT" }),
+    );
+    expect(timeSeriesApi.getTimeSeries).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "A.timeseries", office: "SWT" }),
+    );
+    expect(result).toEqual({
+      levelData: { "A.level": [2, 100, 0] },
+      tsData: { "A.timeseries": [2, 50, 0] },
+    });
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2);
+  });
+
+  it("requires office only when identifiers need to be loaded", () => {
+    render(
+      <BasinPie projects={["A"]} levelIds={["A.level"]} tsids={["A.timeseries"]} />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain("office");
+  });
+
   it("supports suffix overrides, loading, errors, and project selection", () => {
     const suffixes = {
       topOfFlood: ".tf",
@@ -74,7 +125,7 @@ describe("BasinPie", () => {
       <BasinPie
         projects={["X"]}
         levelData={{ "X.tc": [0, 100], "X.ti": [0, 0], "X.tf": [0, 200] }}
-        timeSeriesData={{ "X.c": [0, 40] }}
+        tsData={{ "X.c": [0, 40] }}
         levelIdSuffixes={suffixes}
         timeSeriesIdSuffixes={series}
         onProjectSelect={onProjectSelect}

--- a/lib/components/data/plots/__tests__/RadialFillChart.test.jsx
+++ b/lib/components/data/plots/__tests__/RadialFillChart.test.jsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  RadialFillChart,
+  normalizeSegments,
+  radialSegmentPath,
+} from "../RadialFillChart";
+
+const segments = [
+  { id: "one", label: "One", weight: 3, fillRatio: 1.5, color: "red" },
+  { id: "two", label: "Two", weight: 1, fillRatio: null, color: "blue" },
+];
+
+describe("RadialFillChart", () => {
+  it("normalizes ratios and rejects unusable weights", () => {
+    expect(
+      normalizeSegments([
+        ...segments,
+        { id: "zero", label: "Zero", weight: 0, fillRatio: 0.5 },
+        { id: "invalid", label: "Invalid", weight: Number.NaN, fillRatio: 0.5 },
+      ]),
+    ).toEqual([{ ...segments[0], fillRatio: 1 }, segments[1]]);
+  });
+
+  it("creates finite paths, including a full-circle segment", () => {
+    expect(radialSegmentPath(100, 100, 80, 0, 360)).toMatch(/A 80 80 0 1 1/);
+    expect(radialSegmentPath(100, 100, 0, 0, 90)).toBe("");
+  });
+
+  it("renders percentages, missing data, and escaped text", () => {
+    const unsafeLabel = '<script>alert("x")</script>';
+    const { container } = render(
+      <RadialFillChart
+        segments={[
+          ...segments,
+          { id: "safe", label: unsafeLabel, weight: 1, fillRatio: 0.5 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("One 100%")).toBeTruthy();
+    expect(screen.getByText("Two Missing ⚠")).toBeTruthy();
+    expect(screen.getByText(`${unsafeLabel} 50%`)).toBeTruthy();
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.innerHTML).not.toContain("NaN");
+  });
+
+  it("renders reference marks above filled segments", () => {
+    const { container } = render(<RadialFillChart segments={segments} />);
+    const layers = container.querySelectorAll("[data-chart-layer]");
+
+    expect(Array.from(layers, (layer) => layer.dataset.chartLayer)).toEqual([
+      "segments",
+      "reference-marks",
+    ]);
+    expect(
+      container
+        .querySelector('[data-chart-layer="reference-marks"] text')
+        ?.getAttribute("paint-order"),
+    ).toBe("stroke");
+  });
+
+  it("supports pointer and keyboard selection", () => {
+    const onSegmentSelect = vi.fn();
+    render(<RadialFillChart segments={segments} onSegmentSelect={onSegmentSelect} />);
+
+    const first = screen.getByRole("button", { name: "One: 100% full" });
+    fireEvent.click(first);
+    fireEvent.keyDown(first, { key: "Enter" });
+    fireEvent.keyDown(first, { key: " " });
+
+    expect(onSegmentSelect).toHaveBeenCalledTimes(3);
+    expect(onSegmentSelect).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: "one" }),
+    );
+  });
+
+  it("updates data, reports an empty state, and supports static markup", () => {
+    const { rerender } = render(<RadialFillChart segments={segments} />);
+    rerender(
+      <RadialFillChart
+        segments={[{ id: "new", label: "New", weight: 2, fillRatio: 0.25 }]}
+      />,
+    );
+    expect(screen.getByText("New 25%")).toBeTruthy();
+    rerender(<RadialFillChart segments={[]} />);
+    expect(screen.getByRole("status").textContent).toBe("No chart data is available.");
+
+    const markup = renderToStaticMarkup(
+      <RadialFillChart segments={segments} title="Storage" caption="Updated now" />,
+    );
+    expect(markup).toContain("<svg");
+    expect(markup).toContain("Updated now");
+  });
+});

--- a/lib/components/data/plots/__tests__/RadialFillChart.test.jsx
+++ b/lib/components/data/plots/__tests__/RadialFillChart.test.jsx
@@ -3,6 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import {
   RadialFillChart,
+  clampedTextX,
+  estimatedTextWidth,
+  fittedFontSize,
+  layoutSegmentLabels,
   normalizeSegments,
   radialSegmentPath,
 } from "../RadialFillChart";
@@ -26,6 +30,43 @@ describe("RadialFillChart", () => {
   it("creates finite paths, including a full-circle segment", () => {
     expect(radialSegmentPath(100, 100, 80, 0, 360)).toMatch(/A 80 80 0 1 1/);
     expect(radialSegmentPath(100, 100, 0, 0, 90)).toBe("");
+  });
+
+  it("keeps labels inside the view box and fits long text", () => {
+    const text = "KEYS 75%";
+    const fontSize = 16;
+    const x = clampedTextX(5, text, fontSize, 600);
+    const halfWidth = estimatedTextWidth(text, fontSize) / 2;
+
+    expect(x - halfWidth).toBeGreaterThanOrEqual(fontSize / 2);
+    expect(clampedTextX(595, text, fontSize, 600) + halfWidth).toBeLessThanOrEqual(
+      600 - fontSize / 2,
+    );
+    expect(fittedFontSize("A very long chart caption", 16, 80)).toBeLessThan(16);
+  });
+
+  it("separates labels clustered at the top of a large chart", () => {
+    const layouts = layoutSegmentLabels(
+      [
+        { label: "A", fillRatio: 0.01, startAngle: 0, endAngle: 4 },
+        { label: "B", fillRatio: 0.02, startAngle: 4, endAngle: 10 },
+        { label: "C", fillRatio: 0.03, startAngle: 10, endAngle: 18 },
+      ],
+      {
+        centerX: 300,
+        centerY: 300,
+        radius: 240,
+        fontSize: 16,
+        viewBoxWidth: 600,
+        viewBoxHeight: 600,
+        title: "Storage",
+        caption: "Updated now",
+      },
+    );
+
+    expect(layouts[0].labelY).toBeGreaterThanOrEqual(48);
+    expect(layouts[1].labelY - layouts[0].labelY).toBeGreaterThanOrEqual(20);
+    expect(layouts[2].labelY - layouts[1].labelY).toBeGreaterThanOrEqual(20);
   });
 
   it("renders percentages, missing data, and escaped text", () => {

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -11,6 +11,8 @@ import {
 } from "./components/data/tables/tableData";
 import GageMap from "./components/data/maps/GageMap";
 import CWMSPlot from "./components/data/plots/CWMSPlot";
+import BasinPie from "./components/data/plots/BasinPie";
+import RadialFillChart from "./components/data/plots/RadialFillChart";
 import CdaLatestValueCard from "./components/data/cards/CdaLatestValueCard";
 import DataStatus from "./components/data/summary/DataStatus";
 
@@ -53,6 +55,10 @@ import useCdaOffices from "./components/data/hooks/useCdaOffices";
 import useNwpsGauge from "./components/data/hooks/useNwpsGauge";
 import useNwpsGaugeData from "./components/data/hooks/useNwpsGaugeData";
 import useDataStatusFile from "./components/data/hooks/useDataStatusFile";
+import {
+  fetchCdaLevelTimeSeries,
+  fetchCdaLevelValues,
+} from "./components/data/helpers/levels";
 
 // files
 import useCdaBlob from "./components/data/hooks/useCdaBlob";
@@ -89,6 +95,8 @@ export {
   downloadBlob,
   GageMap,
   CWMSPlot,
+  BasinPie,
+  RadialFillChart,
   CdaLatestValueCard,
   CdaUrlProvider,
   DataStatus,
@@ -104,6 +112,8 @@ export {
   useCdaTimeSeriesGroup,
   useCdaOffices,
   useDataStatusFile,
+  fetchCdaLevelTimeSeries,
+  fetchCdaLevelValues,
   useDebounce,
   useNwpsGauge,
   useNwpsGaugeData,


### PR DESCRIPTION
## Summary

- add a reusable, accessible `RadialFillChart` SVG component
- add the CWMS-aware `BasinPie` adapter for preloaded level/time-series data or optional CDA loading by `levelIds` and `tsids`
- document both data modes with working examples
- fit and position chart labels, titles, percentage guides, and captions to avoid clipping and collisions

## Why

The SWT sites maintained separate D3 BasinPie renderers, including expression-based label positioning. Moving the interactive renderer into Groundwork Water provides one declarative React/SVG implementation while keeping application navigation and project configuration in the consumers.

## Impact

Consumers can provide loaded CWMS data or identifiers plus an office. The chart handles loading, error, empty, missing-data, mouse, and keyboard states and remains compatible with static SVG markup.

## Validation

- `npm test` - 44 tests passed
- `npm run build-lib`
- `npm run build-docs`
- public SWT production build against the linked package
- internal SWT `cwbi-local` build against the linked package
