### PR TITLE
Feat/form load nearest

### DIFF
--- a/.changeset/hip-wombats-melt.md
+++ b/.changeset/hip-wombats-melt.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Add nearest value to CWMSForms

--- a/.changeset/hip-wombats-melt.md
+++ b/.changeset/hip-wombats-melt.md
@@ -2,4 +2,6 @@
 "@usace-watermanagement/groundwork-water": minor
 ---
 
-Add nearest value to CWMSForms
+Add nearest value loading to CWMSForms. Setting `loadNearest` on CWMSInput, CWMSInputTable or CWMSSpreadsheet pre-populates fields with the time series value nearest the form's calendar time, using a `prev`, `next` or `nearest` strategy. Loaded values never overwrite what a user has typed, and `showValueTimestamp` surfaces where each value came from.
+
+Fetching is handled by CWMSForm rather than by each input: inputs declare the series and time offsets they need, and the form issues one request per distinct time series and unit no matter how many inputs asked for it, so overlapping components share a single request. The shared window covers the union of registered time offsets and is trimmed to what the registered strategies require, while each input still resolves its own strategy against the shared result.

--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"@usace-watermanagement/groundwork-water": minor
+---
+
+Route nearest-value loading through a form-level orchestrator. Inputs now declare which series and time offsets they need and read values back from CWMSForm, instead of each component fetching for itself. Overlapping components share one request per tsid+units, the fetch window is trimmed to what the registered strategies actually require, and requests set an explicit page size so a truncated page can no longer hand back a stale value.

--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,5 +1,0 @@
----
-"@usace-watermanagement/groundwork-water": minor
----
-
-Route nearest-value loading through a form-level orchestrator. Inputs now declare which series and time offsets they need and read values back from CWMSForm, instead of each component fetching for itself. Overlapping components share one request per tsid+units, the fetch window is trimmed to what the registered strategies actually require, and requests set an explicit page size so a truncated page can no longer hand back a stale value.

--- a/docs/src/pages/docs/forms/cwms-form.jsx
+++ b/docs/src/pages/docs/forms/cwms-form.jsx
@@ -547,6 +547,22 @@ function CWMSFormDocs() {
         caller.
       </Text>
 
+      <div className="font-bold text-lg pt-4">After a submit</div>
+      <Text className="mb-4">
+        Submitting invalidates the queries for the time series that were written, so the
+        form re-reads them. CDA caches time series responses for several minutes, which
+        means that read can come back with the value as it was <em>before</em> the
+        submission - the operator would watch their entry revert to the old number.
+      </Text>
+      <Text className="mb-4">
+        To avoid that, the form keeps the values it just wrote and shows them in place
+        of the cached response, until CDA reports the same value back and the local copy
+        is dropped. This needs no configuration. Be aware that what you see immediately
+        after submitting is what the form sent, not a confirmed read-back - the
+        displayed value only reflects a genuine server read once CDA&apos;s cache has
+        expired.
+      </Text>
+
       <Divider text="Controlling Form Reset Behavior" className="mt-8" />
       <Text className="mb-4">
         By default, forms automatically reset all fields after successful submission.

--- a/docs/src/pages/docs/forms/cwms-form.jsx
+++ b/docs/src/pages/docs/forms/cwms-form.jsx
@@ -127,6 +127,12 @@ const componentProps = [
     desc: "Callback fired when the calendar timestamp changes. Receives the snapped Date object.",
   },
   {
+    name: "onLoadError",
+    type: "function",
+    default: "undefined",
+    desc: "Callback fired when loading nearest values fails or times out. Receives the error. Without it a failed load is indistinguishable from no data existing - the fields simply stay empty.",
+  },
+  {
     name: "toastAutoClose",
     type: "number|boolean",
     default: "5000",
@@ -546,6 +552,26 @@ function CWMSFormDocs() {
         <Code>useLoadNearestValues</Code> hook does the same resolution for a single
         caller.
       </Text>
+
+      <div className="font-bold text-lg pt-4">When loading fails</div>
+      <Text className="mb-4">
+        A failed or timed-out fetch leaves the fields empty, which looks exactly like a
+        series having no data - an operator could reasonably read a blank cell as real.
+        Pass <Code>onLoadError</Code> to be told when that happens and surface it
+        however suits your app.
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`<CWMSForm
+  office="SWT"
+  onLoadError={(error) => {
+    console.error("Could not load previous values", error);
+    showBanner("Previous values are unavailable - enter readings manually.");
+  }}
+>
+  {/* ... */}
+</CWMSForm>`}
+      </CodeBlock>
 
       <div className="font-bold text-lg pt-4">After a submit</div>
       <Text className="mb-4">

--- a/docs/src/pages/docs/forms/cwms-form.jsx
+++ b/docs/src/pages/docs/forms/cwms-form.jsx
@@ -524,6 +524,29 @@ function CWMSFormDocs() {
 </CWMSForm>`}
       </CodeBlock>
 
+      <Divider text="Shared Nearest-Value Loading" className="mt-8" />
+      <Text className="mb-4">
+        When inputs opt into <Code>loadNearest</Code>, the fetching is handled by the
+        form, not by each input. Every input registers the series and time offsets it
+        needs, and CWMSForm issues one request per distinct time series and unit -
+        however many inputs asked for it. Two tables that both reference the same TSID
+        share a single request rather than each issuing their own.
+      </Text>
+      <Text className="mb-4">
+        The shared fetch window covers the union of every registered time offset, and is
+        trimmed to what the registered strategies need: if every input uses{" "}
+        <Code>prev</Code>, no future data is requested. Each input still resolves its
+        own <Code>prev</Code> / <Code>next</Code> / <Code>nearest</Code> strategy
+        against the shared result, so inputs with different strategies do not cost extra
+        requests.
+      </Text>
+      <Text className="mb-4">
+        This requires an <Code>office</Code> on the form. Outside a CWMSForm, or when
+        you want to fetch independently, the standalone{" "}
+        <Code>useLoadNearestValues</Code> hook does the same resolution for a single
+        caller.
+      </Text>
+
       <Divider text="Controlling Form Reset Behavior" className="mt-8" />
       <Text className="mb-4">
         By default, forms automatically reset all fields after successful submission.

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -76,7 +76,7 @@ const componentProps = [
     name: "loadNearest",
     type: "string",
     default: "prev",
-    desc: "Load nearest value strategy (prev, next, nearest).",
+    desc: "Strategy for auto-loading the nearest time series values into cells. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
   },
   {
     name: "onChange",
@@ -223,6 +223,52 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
     ]}
     precision={2}
     units="EN"
+  />
+</CWMSForm>`}
+      </CodeBlock>
+
+      <Divider text="Load Nearest Values" className="mt-8" />
+      <Text className="mb-4">
+        When columns have a <Code className="p-1">tsid</Code> and the parent{" "}
+        <Code className="p-1">CWMSForm</Code> provides an{" "}
+        <Code className="p-1">office</Code>, CWMSInputTable automatically fetches the
+        nearest time series values and pre-populates cells. The{" "}
+        <Code className="p-1">loadNearest</Code> prop controls the strategy:
+      </Text>
+      <ul className="list-disc ml-6 mb-4">
+        <li>
+          <Code className="p-1">prev</Code> (default) — last value at or before each
+          target time
+        </li>
+        <li>
+          <Code className="p-1">next</Code> — first value at or after each target time
+        </li>
+        <li>
+          <Code className="p-1">nearest</Code> — closest value by absolute time
+          difference
+        </li>
+      </ul>
+      <Text className="mb-4">
+        Cells show a Loading placeholder while data is being fetched. Once a user edits
+        a cell, the loaded value will not overwrite their input. Changing the calendar
+        date resets the loaded values.
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`// Auto-populate cells with the most recent time series values
+<CWMSForm
+  office="SWT"
+  cdaUrl="https://cwms-data.usace.army.mil/cwms-data"
+  showCalendar={true}
+  calendarInterval="hour"
+>
+  <CWMSInputTable
+    columns={[
+      { tsid: "KEYS.Elev.Inst.1Hour.0.Ccp-Rev", label: "Elevation (ft)", units: "ft", precision: 2 },
+      { tsid: "KEYS.Flow.Inst.1Hour.0.Ccp-Rev", label: "Flow (cfs)", units: "cfs", precision: 0 }
+    ]}
+    timeoffsets={[0, 3600, 7200]}
+    loadNearest="prev"
   />
 </CWMSForm>`}
       </CodeBlock>

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -73,6 +73,12 @@ const componentProps = [
     desc: "Whether to allow missing data in submissions.",
   },
   {
+    name: "showValueTimestamp",
+    type: "boolean",
+    default: "false",
+    desc: "When true, shows the source datetime of the loaded nearest value as a tooltip on each input cell. The tooltip is removed when the user edits the cell.",
+  },
+  {
     name: "loadNearest",
     type: "string",
     default: "prev",

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -81,8 +81,8 @@ const componentProps = [
   {
     name: "loadNearest",
     type: "string",
-    default: "prev",
-    desc: "Strategy for auto-loading the nearest time series values into cells. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
+    default: "undefined (feature off)",
+    desc: "Opt-in strategy for auto-loading the nearest time series values into cells. When omitted, no values are fetched. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
   },
   {
     name: "onChange",
@@ -235,16 +235,17 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
 
       <Divider text="Load Nearest Values" className="mt-8" />
       <Text className="mb-4">
-        When columns have a <Code className="p-1">tsid</Code> and the parent{" "}
+        This is an opt-in feature. When the <Code className="p-1">loadNearest</Code>{" "}
+        prop is set (and columns have a <Code className="p-1">tsid</Code> and the parent{" "}
         <Code className="p-1">CWMSForm</Code> provides an{" "}
-        <Code className="p-1">office</Code>, CWMSInputTable automatically fetches the
-        nearest time series values and pre-populates cells. The{" "}
-        <Code className="p-1">loadNearest</Code> prop controls the strategy:
+        <Code className="p-1">office</Code>), CWMSInputTable fetches the nearest time
+        series values and pre-populates cells. With{" "}
+        <Code className="p-1">loadNearest</Code> omitted, no values are fetched. The
+        prop value selects the strategy:
       </Text>
       <ul className="list-disc ml-6 mb-4">
         <li>
-          <Code className="p-1">prev</Code> (default) — last value at or before each
-          target time
+          <Code className="p-1">prev</Code> — last value at or before each target time
         </li>
         <li>
           <Code className="p-1">next</Code> — first value at or after each target time

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -280,6 +280,76 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
 </CWMSForm>`}
       </CodeBlock>
 
+      <Divider text="Previous Values as a Reference Column" className="mt-8" />
+      <Text className="mb-4">
+        Loading the previous value straight into the entry cells is not always what you
+        want - an operator updating one gate out of thirty may prefer to see the last
+        recorded setting <em>next to</em> an empty field rather than edit on top of it.
+        Pair a disabled reference table with a normal entry table to get that.
+      </Text>
+      <Text className="mb-4">
+        A disabled input does not register with the form, so the reference table
+        displays values but never submits them. The entry table registers as usual and
+        is the only one that writes. Because fetching happens at the form level, both
+        tables referencing the same time series still cost a single request.
+      </Text>
+
+      <div className="overflow-x-auto">
+        <CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
+          <div className="font-medium mb-1">Last recorded</div>
+          <CWMSInputTable
+            columns={[
+              { tsid: "Gate 1", label: "Gate 1", units: "ft", precision: 2 },
+              { tsid: "Gate 2", label: "Gate 2", units: "ft", precision: 2 },
+            ]}
+            timeoffsets={[0]}
+            loadNearest="prev"
+            showValueTimestamp={true}
+            showTimestamps={false}
+            disable
+          />
+          <div className="font-medium mb-1 mt-4">New setting</div>
+          <CWMSInputTable
+            columns={[
+              { tsid: "Gate 1", label: "Gate 1", units: "ft", precision: 2 },
+              { tsid: "Gate 2", label: "Gate 2", units: "ft", precision: 2 },
+            ]}
+            timeoffsets={[0]}
+            showTimestamps={false}
+          />
+        </CWMSForm>
+      </div>
+
+      <CodeBlock language="jsx">
+        {`// Reference table: shows the last recorded value, never submits.
+// Entry table: starts empty and is the one that writes.
+const GATES = [
+  { tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev", label: "Gate 1", units: "ft", precision: 2 },
+  { tsid: "PROJ.Opening-Gate2.Inst.15Minutes.0.Ccp-Rev", label: "Gate 2", units: "ft", precision: 2 },
+];
+
+<CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
+  <CWMSInputTable
+    columns={GATES}
+    timeoffsets={[0]}
+    loadNearest="prev"
+    showValueTimestamp={true}   // hover a cell to see when the value is from
+    disable                     // disabled inputs do not register, so this never submits
+  />
+  <CWMSInputTable
+    columns={GATES}
+    timeoffsets={[0]}
+  />
+</CWMSForm>`}
+      </CodeBlock>
+
+      <Text className="mb-4">
+        Use <Code className="p-1">loadNearest</Code> directly on the entry table instead
+        when the operator is confirming or nudging existing values rather than entering
+        them fresh - the previous value becomes the starting point, and anything they do
+        not touch is submitted unchanged.
+      </Text>
+
       <Divider text="Without Timestamps" className="mt-8" />
       <Text className="mb-4">
         You can hide the timestamp column for a more compact view.

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -364,9 +364,10 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
         Entries in <Code className="p-1">timeoffsets</Code> may be objects instead of
         plain numbers, carrying the same overrides a column can:{" "}
         <Code className="p-1">loadNearest</Code>, <Code className="p-1">disabled</Code>,{" "}
-        <Code className="p-1">id</Code> and <Code className="p-1">label</Code>. That
-        gives you the reference pattern along the other axis - useful in a transposed
-        table, or when the same instant needs both a recorded row and an entry row.
+        <Code className="p-1">readonly</Code>, <Code className="p-1">id</Code> and{" "}
+        <Code className="p-1">label</Code>. That gives you the reference pattern along
+        the other axis - useful in a transposed table, or when the same instant needs
+        both a recorded row and an entry row.
       </Text>
 
       <Text className="mb-4">
@@ -392,7 +393,7 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
                 id: "last",
                 label: "Last recorded",
                 loadNearest: "prev",
-                disabled: true,
+                readonly: true,
               },
               { offset: 0, id: "new", label: "New setting" },
             ]}
@@ -414,7 +415,7 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
       { tsid: "PROJ.Opening-Gate3.Inst.15Minutes.0.Ccp-Rev", label: "Gate 3" },
     ]}
     timeoffsets={[
-      { offset: 0, id: "last", label: "Last recorded", loadNearest: "prev", disabled: true },
+      { offset: 0, id: "last", label: "Last recorded", loadNearest: "prev", readonly: true },
       { offset: 0, id: "new", label: "New setting" },
     ]}
     showTimestamps={false}
@@ -428,6 +429,17 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
   timeoffsets={[-3600, 0, { offset: 3600, loadNearest: "next" }]}
 />`}
       </CodeBlock>
+
+      <Text className="mb-4">
+        The reference row above uses <Code className="p-1">readonly</Code> rather than{" "}
+        <Code className="p-1">disabled</Code>, so it stays focusable and its value can
+        be selected and copied. Note the trade-off: a read-only row still registers with
+        the form, and both rows here sit at the same offset on the same time series, so
+        they share one registration. The entry row is declared second and therefore wins
+        - swap the order and the recorded value would be submitted instead. Use{" "}
+        <Code className="p-1">disabled</Code> on the reference row if you would rather
+        not depend on that.
+      </Text>
 
       <Text className="mb-4">
         Where both a column and a row set the same option, the more specific wins:

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -785,8 +785,33 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
             default: "table disable",
             desc: "Disables just this row. A disabled row does not register with the form, so it displays values but never submits them, and its cells reject edits.",
           },
+          {
+            name: "readonly",
+            type: "boolean",
+            default: "table readonly",
+            desc: "Makes just this row read-only. Unlike disabled, a read-only row still registers and still submits - use it for a value the operator should see and send but not change. It is not a substitute for disabled in the reference pattern (see below).",
+          },
         ]}
       />
+
+      <div className="mt-6 p-4 bg-amber-50 border border-amber-200 rounded">
+        <Text className="font-semibold mb-2">readonly is not disabled</Text>
+        <Text className="text-sm">
+          Both stop the operator typing, but only <Code className="p-1">disabled</Code>{" "}
+          keeps a cell out of the submission. A <Code className="p-1">readonly</Code>{" "}
+          cell still registers with the form and still submits its value.
+        </Text>
+        <Text className="text-sm mt-2">
+          That is why the reference pattern above uses{" "}
+          <Code className="p-1">disabled</Code>. The form keys its registry by time
+          series and time offset, so a read-only reference cell and the entry cell
+          beside it - same tsid, same offset - would register under the same key and one
+          would silently replace the other. Reach for{" "}
+          <Code className="p-1">readonly</Code> when a value should be sent but not
+          edited, and <Code className="p-1">disabled</Code> when it should only be
+          displayed.
+        </Text>
+      </div>
 
       <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded">
         <Text className="font-semibold mb-2">Property Fallback Chain:</Text>

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -284,67 +284,83 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
       <Text className="mb-4">
         Loading the previous value straight into the entry cells is not always what you
         want - an operator updating one gate out of thirty may prefer to see the last
-        recorded setting <em>next to</em> an empty field rather than edit on top of it.
-        Pair a disabled reference table with a normal entry table to get that.
+        recorded setting <em>beside</em> an empty field rather than edit on top of it.
+        Both <Code className="p-1">loadNearest</Code> and{" "}
+        <Code className="p-1">disabled</Code> can be set per column, so a single table
+        can hold a read-only reference column next to the editable one.
       </Text>
       <Text className="mb-4">
-        A disabled input does not register with the form, so the reference table
-        displays values but never submits them. The entry table registers as usual and
-        is the only one that writes. Because fetching happens at the form level, both
-        tables referencing the same time series still cost a single request.
+        Two columns may point at the same time series. Give each an{" "}
+        <Code className="p-1">id</Code> so they keep separate cell state - without one
+        they share a cell and editing the entry column would change the reference column
+        too. A disabled column never registers with the form, so only the entry column
+        submits, and because fetching happens at the form level both columns still cost
+        a single request.
       </Text>
 
       <div className="overflow-x-auto">
         <CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
-          <div className="font-medium mb-1">Last recorded</div>
           <CWMSInputTable
             columns={[
-              { tsid: "Gate 1", label: "Gate 1", units: "ft", precision: 2 },
-              { tsid: "Gate 2", label: "Gate 2", units: "ft", precision: 2 },
+              {
+                tsid: "Gate 1",
+                id: "gate1-prev",
+                label: "Gate 1 (last)",
+                loadNearest: "prev",
+                disabled: true,
+              },
+              { tsid: "Gate 1", id: "gate1", label: "Gate 1 (new)" },
+              {
+                tsid: "Gate 2",
+                id: "gate2-prev",
+                label: "Gate 2 (last)",
+                loadNearest: "prev",
+                disabled: true,
+              },
+              { tsid: "Gate 2", id: "gate2", label: "Gate 2 (new)" },
             ]}
             timeoffsets={[0]}
-            loadNearest="prev"
             showValueTimestamp={true}
-            showTimestamps={false}
-            disable
-          />
-          <div className="font-medium mb-1 mt-4">New setting</div>
-          <CWMSInputTable
-            columns={[
-              { tsid: "Gate 1", label: "Gate 1", units: "ft", precision: 2 },
-              { tsid: "Gate 2", label: "Gate 2", units: "ft", precision: 2 },
-            ]}
-            timeoffsets={[0]}
             showTimestamps={false}
           />
         </CWMSForm>
       </div>
 
       <CodeBlock language="jsx">
-        {`// Reference table: shows the last recorded value, never submits.
-// Entry table: starts empty and is the one that writes.
-const GATES = [
-  { tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev", label: "Gate 1", units: "ft", precision: 2 },
-  { tsid: "PROJ.Opening-Gate2.Inst.15Minutes.0.Ccp-Rev", label: "Gate 2", units: "ft", precision: 2 },
-];
-
+        {`// A read-only "last recorded" column beside each entry column.
+// Same tsid on both - the id is what keeps their cell state separate.
 <CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
   <CWMSInputTable
-    columns={GATES}
+    columns={[
+      {
+        tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev",
+        id: "gate1-prev",
+        label: "Gate 1 (last)",
+        loadNearest: "prev",   // only this column loads
+        disabled: true,        // display only - never registers, never submits
+      },
+      {
+        tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev",
+        id: "gate1",
+        label: "Gate 1 (new)", // starts empty, this is what submits
+      },
+    ]}
     timeoffsets={[0]}
-    loadNearest="prev"
-    showValueTimestamp={true}   // hover a cell to see when the value is from
-    disable                     // disabled inputs do not register, so this never submits
-  />
-  <CWMSInputTable
-    columns={GATES}
-    timeoffsets={[0]}
+    showValueTimestamp={true}  // hover a cell to see when the value is from
   />
 </CWMSForm>`}
       </CodeBlock>
 
       <Text className="mb-4">
-        Use <Code className="p-1">loadNearest</Code> directly on the entry table instead
+        A column may also override the table-level strategy - set{" "}
+        <Code className="p-1">loadNearest</Code> on the table for the common case and on
+        an individual column where it should differ. Columns with different strategies
+        still share one request; only the value each one picks out of the result
+        changes.
+      </Text>
+
+      <Text className="mb-4">
+        Use <Code className="p-1">loadNearest</Code> on the table as a whole instead
         when the operator is confirming or nudging existing values rather than entering
         them fresh - the previous value becomes the starting point, and anything they do
         not touch is submitted unchanged.
@@ -599,6 +615,24 @@ const GATES = [
             type: "string",
             default: "required",
             desc: "Time Series ID for this column. This is the only required property.",
+          },
+          {
+            name: "id",
+            type: "string",
+            default: "tsid value",
+            desc: "Identity for this column's cells. Only needed when two columns reference the same tsid - give each an id so they keep separate values instead of sharing one cell.",
+          },
+          {
+            name: "loadNearest",
+            type: "string",
+            default: "table loadNearest",
+            desc: "Per-column override of the table's loadNearest strategy ('prev', 'next', 'nearest'). Set it on a single column to load only that column, or to use a different strategy from the rest of the table. Columns with different strategies still share one request.",
+          },
+          {
+            name: "disabled",
+            type: "boolean",
+            default: "table disable",
+            desc: "Disables just this column. A disabled column does not register with the form, so it displays values but never submits them - which is what lets it sit beside an editable column on the same tsid.",
           },
           {
             name: "label",

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -380,9 +380,12 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
         <Code className="p-1">highlightChanged={"{false}"}</Code> to turn that off.
       </Text>
       <Text className="mb-4">
-        The status is worked out by comparing the cell against the value loaded for it,
-        not by remembering that you typed - so typing a value and then putting the
-        original back correctly reads as unchanged.
+        The status is worked out by comparing the cell against the value it started
+        with, not by remembering that you typed - so typing a value and then putting the
+        original back correctly reads as unchanged. Where a column supplies{" "}
+        <Code className="p-1">defaultValues</Code> that default is the baseline, since a
+        default takes precedence over loading and the operator has not touched the cell
+        just because it differs from what CDA returned.
       </Text>
       <Text className="mb-4">
         For your own treatment, <Code className="p-1">cellClassName</Code> is called per

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -369,16 +369,58 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
         table, or when the same instant needs both a recorded row and an entry row.
       </Text>
 
+      <Text className="mb-4">
+        Combined with <Code className="p-1">transpose</Code> this gives the layout most
+        gate-entry screens want: one row per parameter, a read-only column showing what
+        was last recorded, and an empty column to type into. Rows become the visual
+        columns when transposed, so the row overrides are what define the two columns
+        below.
+      </Text>
+
+      <div className="overflow-x-auto">
+        <CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
+          <CWMSInputTable
+            transpose={true}
+            columns={[
+              { tsid: "Gate 1", label: "Gate 1" },
+              { tsid: "Gate 2", label: "Gate 2" },
+              { tsid: "Gate 3", label: "Gate 3" },
+            ]}
+            timeoffsets={[
+              {
+                offset: 0,
+                id: "last",
+                label: "Last recorded",
+                loadNearest: "prev",
+                disabled: true,
+              },
+              { offset: 0, id: "new", label: "New setting" },
+            ]}
+            showTimestamps={false}
+            showValueTimestamp={true}
+          />
+        </CWMSForm>
+      </div>
+
       <CodeBlock language="jsx">
-        {`// Same instant twice: one row shows the last value, the next is for entry.
-// As with columns, the id keeps their cell state separate.
-<CWMSInputTable
-  columns={[{ tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev", label: "Gate 1" }]}
-  timeoffsets={[
-    { offset: 0, id: "last", label: "Last", loadNearest: "prev", disabled: true },
-    { offset: 0, id: "new", label: "New" },
-  ]}
-/>
+        {`// Transposed: parameters down the side, "last recorded" and "new" across.
+// The two visual columns come from the two row definitions.
+<CWMSForm office="SWT" showCalendar={true} calendarInterval="hour">
+  <CWMSInputTable
+    transpose={true}
+    columns={[
+      { tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev", label: "Gate 1" },
+      { tsid: "PROJ.Opening-Gate2.Inst.15Minutes.0.Ccp-Rev", label: "Gate 2" },
+      { tsid: "PROJ.Opening-Gate3.Inst.15Minutes.0.Ccp-Rev", label: "Gate 3" },
+    ]}
+    timeoffsets={[
+      { offset: 0, id: "last", label: "Last recorded", loadNearest: "prev", disabled: true },
+      { offset: 0, id: "new", label: "New setting" },
+    ]}
+    showTimestamps={false}
+    showValueTimestamp={true}
+  />
+</CWMSForm>
 
 // Plain numbers still work, and can be mixed with row objects.
 <CWMSInputTable
@@ -706,6 +748,46 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
         ]}
       />
 
+      <div className="font-bold text-lg pt-6 mt-8">Row Configuration Object</div>
+      <Text className="mb-4">
+        Entries in <Code className="p-1">timeoffsets</Code> may be a plain number, or an
+        object with the following properties. Both forms can be mixed in one array.
+      </Text>
+      <PropsTable
+        propsList={[
+          {
+            name: "offset",
+            type: "number",
+            default: "required",
+            desc: "Time offset in seconds from the form's base time. This is what a plain number entry sets.",
+          },
+          {
+            name: "id",
+            type: "string",
+            default: "offset value",
+            desc: "Identity for this row's cells. Only needed when two rows use the same offset - give each an id so they keep separate values instead of sharing one cell.",
+          },
+          {
+            name: "label",
+            type: "string",
+            default: "undefined",
+            desc: "Heading for the row. Used in transposed layouts, where rows are rendered as columns, and when showTimestamps is false.",
+          },
+          {
+            name: "loadNearest",
+            type: "string",
+            default: "table loadNearest",
+            desc: "Per-row override of the loadNearest strategy ('prev', 'next', 'nearest'). Set it on a single row to load only that row. Rows with different strategies still share one request.",
+          },
+          {
+            name: "disabled",
+            type: "boolean",
+            default: "table disable",
+            desc: "Disables just this row. A disabled row does not register with the form, so it displays values but never submits them, and its cells reject edits.",
+          },
+        ]}
+      />
+
       <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded">
         <Text className="font-semibold mb-2">Property Fallback Chain:</Text>
         <Text className="text-sm">
@@ -719,6 +801,14 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
           This allows you to set global defaults and selectively override them for
           specific columns.
         </Text>
+        <Text className="text-sm mt-3">
+          For the options a row can also set - <Code className="p-1">loadNearest</Code>{" "}
+          and <Code className="p-1">disabled</Code> - the row sits between the column
+          and the component-wide prop:
+        </Text>
+        <Code className="block mt-2 p-2 bg-white">
+          column.property → row.property → global property
+        </Code>
       </div>
     </DocsPage>
   );

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -16,7 +16,7 @@ const componentProps = [
     name: "timeoffsets",
     type: "array",
     default: "[]",
-    desc: "Array of time offsets in seconds for row timestamps.",
+    desc: "Row definitions. Each entry is either a time offset in seconds, or an object { offset, id, label, loadNearest, disabled } to override those settings for that row. The two forms can be mixed.",
   },
   {
     name: "showTimestamps",
@@ -354,9 +354,42 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
       <Text className="mb-4">
         A column may also override the table-level strategy - set{" "}
         <Code className="p-1">loadNearest</Code> on the table for the common case and on
-        an individual column where it should differ. Columns with different strategies
+        an individual column where it should differ. Cells with different strategies
         still share one request; only the value each one picks out of the result
         changes.
+      </Text>
+
+      <div className="font-bold text-lg pt-4">Rows can override too</div>
+      <Text className="mb-4">
+        Entries in <Code className="p-1">timeoffsets</Code> may be objects instead of
+        plain numbers, carrying the same overrides a column can:{" "}
+        <Code className="p-1">loadNearest</Code>, <Code className="p-1">disabled</Code>,{" "}
+        <Code className="p-1">id</Code> and <Code className="p-1">label</Code>. That
+        gives you the reference pattern along the other axis - useful in a transposed
+        table, or when the same instant needs both a recorded row and an entry row.
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`// Same instant twice: one row shows the last value, the next is for entry.
+// As with columns, the id keeps their cell state separate.
+<CWMSInputTable
+  columns={[{ tsid: "PROJ.Opening-Gate1.Inst.15Minutes.0.Ccp-Rev", label: "Gate 1" }]}
+  timeoffsets={[
+    { offset: 0, id: "last", label: "Last", loadNearest: "prev", disabled: true },
+    { offset: 0, id: "new", label: "New" },
+  ]}
+/>
+
+// Plain numbers still work, and can be mixed with row objects.
+<CWMSInputTable
+  columns={COLUMNS}
+  timeoffsets={[-3600, 0, { offset: 3600, loadNearest: "next" }]}
+/>`}
+      </CodeBlock>
+
+      <Text className="mb-4">
+        Where both a column and a row set the same option, the more specific wins:
+        column over row, row over the table-level prop.
       </Text>
 
       <Text className="mb-4">

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -79,6 +79,18 @@ const componentProps = [
     desc: "When true, shows the source datetime of the loaded nearest value as a tooltip on each input cell. The tooltip is removed when the user edits the cell.",
   },
   {
+    name: "highlightChanged",
+    type: "boolean",
+    default: "true",
+    desc: "When values have been loaded, dims cells still showing the loaded value and emboldens ones the operator has changed, so it is obvious at a glance which cells will carry new data. Has no effect on cells nothing was loaded for.",
+  },
+  {
+    name: "cellClassName",
+    type: "function",
+    default: "undefined",
+    desc: "Called per cell with its status - { value, loadedValue, loaded, changed, prefilled, key, tsid, offset, column, row } - and whatever it returns is applied as a class on the table cell. Use it to react to changed or unchanged values with your own styling.",
+  },
+  {
     name: "loadNearest",
     type: "string",
     default: "undefined (feature off)",
@@ -357,6 +369,50 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
         an individual column where it should differ. Cells with different strategies
         still share one request; only the value each one picks out of the result
         changes.
+      </Text>
+
+      <div className="font-bold text-lg pt-4">Seeing what you changed</div>
+      <Text className="mb-4">
+        Once values are loaded every cell holds a number, so nothing distinguishes the
+        one gate you moved from the twenty-nine you did not. By default the table dims
+        cells still showing the loaded value and emboldens ones you have changed, so the
+        cells about to carry new data stand out. Set{" "}
+        <Code className="p-1">highlightChanged={"{false}"}</Code> to turn that off.
+      </Text>
+      <Text className="mb-4">
+        The status is worked out by comparing the cell against the value loaded for it,
+        not by remembering that you typed - so typing a value and then putting the
+        original back correctly reads as unchanged.
+      </Text>
+      <Text className="mb-4">
+        For your own treatment, <Code className="p-1">cellClassName</Code> is called per
+        cell with that status and its result is applied to the table cell:
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`<CWMSInputTable
+  columns={GATES}
+  timeoffsets={[0]}
+  loadNearest="prev"
+  cellClassName={({ changed, prefilled, value, loadedValue }) => {
+    if (!changed) return "";
+    // e.g. flag a change larger than a foot
+    return Math.abs(Number(value) - Number(loadedValue)) > 1
+      ? "ring-2 ring-amber-400 rounded"
+      : "bg-emerald-50";
+  }}
+/>`}
+      </CodeBlock>
+
+      <Text className="mb-4">
+        The status object holds <Code className="p-1">value</Code>,{" "}
+        <Code className="p-1">loadedValue</Code>, <Code className="p-1">loaded</Code>,{" "}
+        <Code className="p-1">changed</Code>, <Code className="p-1">prefilled</Code>,{" "}
+        <Code className="p-1">key</Code>, <Code className="p-1">tsid</Code>,{" "}
+        <Code className="p-1">offset</Code>, and the <Code className="p-1">column</Code>{" "}
+        and <Code className="p-1">row</Code> it came from.{" "}
+        <Code className="p-1">loaded</Code> is false where nothing was fetched, in which
+        case there is no baseline and <Code className="p-1">changed</Code> stays false.
       </Text>
 
       <div className="font-bold text-lg pt-4">Rows can override too</div>

--- a/docs/src/pages/docs/forms/cwms-input-table.jsx
+++ b/docs/src/pages/docs/forms/cwms-input-table.jsx
@@ -393,7 +393,7 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
                 id: "last",
                 label: "Last recorded",
                 loadNearest: "prev",
-                readonly: true,
+                disabled: true,
               },
               { offset: 0, id: "new", label: "New setting" },
             ]}
@@ -415,7 +415,7 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
       { tsid: "PROJ.Opening-Gate3.Inst.15Minutes.0.Ccp-Rev", label: "Gate 3" },
     ]}
     timeoffsets={[
-      { offset: 0, id: "last", label: "Last recorded", loadNearest: "prev", readonly: true },
+      { offset: 0, id: "last", label: "Last recorded", loadNearest: "prev", disabled: true },
       { offset: 0, id: "new", label: "New setting" },
     ]}
     showTimestamps={false}
@@ -431,14 +431,12 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
       </CodeBlock>
 
       <Text className="mb-4">
-        The reference row above uses <Code className="p-1">readonly</Code> rather than{" "}
-        <Code className="p-1">disabled</Code>, so it stays focusable and its value can
-        be selected and copied. Note the trade-off: a read-only row still registers with
-        the form, and both rows here sit at the same offset on the same time series, so
-        they share one registration. The entry row is declared second and therefore wins
-        - swap the order and the recorded value would be submitted instead. Use{" "}
-        <Code className="p-1">disabled</Code> on the reference row if you would rather
-        not depend on that.
+        The reference row uses <Code className="p-1">disabled</Code> rather than{" "}
+        <Code className="p-1">readonly</Code>. Both rows here sit at the same offset on
+        the same time series, and a read-only row still registers with the form, so the
+        two would share one registration and whichever was declared last would win.
+        Disabling the reference row keeps it out of the submission entirely, so the
+        entry row is unambiguously the one that submits.
       </Text>
 
       <Text className="mb-4">

--- a/docs/src/pages/docs/forms/cwms-input.jsx
+++ b/docs/src/pages/docs/forms/cwms-input.jsx
@@ -63,8 +63,8 @@ const componentProps = [
   {
     name: "loadNearest",
     type: "string",
-    default: "prev",
-    desc: "Strategy for auto-loading the nearest time series value. 'prev' loads the last value at or before the target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires a tsid and an office on the parent CWMSForm.",
+    default: "undefined (feature off)",
+    desc: "Opt-in strategy for auto-loading the nearest time series value. When omitted, no value is fetched. 'prev' loads the last value at or before the target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires a tsid and an office on the parent CWMSForm.",
   },
   {
     name: "showValueTimestamp",
@@ -206,16 +206,16 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
 
       <Divider text="Load Nearest Value" className="mt-8" />
       <Text className="mb-4">
-        When a <Code className="p-1">tsid</Code> is provided and the parent{" "}
+        This is an opt-in feature. When the <Code className="p-1">loadNearest</Code>{" "}
+        prop is set (and a <Code className="p-1">tsid</Code> is provided and the parent{" "}
         <Code className="p-1">CWMSForm</Code> has an <Code className="p-1">office</Code>
-        , CWMSInput automatically fetches the nearest time series value and
-        pre-populates the input. The <Code className="p-1">loadNearest</Code> prop
-        controls the strategy:
+        ), CWMSInput fetches the nearest time series value and pre-populates the input.
+        With <Code className="p-1">loadNearest</Code> omitted, no value is fetched. The
+        prop value selects the strategy:
       </Text>
       <ul className="list-disc ml-6 mb-4">
         <li>
-          <Code className="p-1">prev</Code> (default) — last value at or before the
-          target time
+          <Code className="p-1">prev</Code> — last value at or before the target time
         </li>
         <li>
           <Code className="p-1">next</Code> — first value at or after the target time

--- a/docs/src/pages/docs/forms/cwms-input.jsx
+++ b/docs/src/pages/docs/forms/cwms-input.jsx
@@ -55,6 +55,18 @@ const componentProps = [
     desc: "Time offset in seconds for data timestamps.",
   },
   {
+    name: "timeOffset",
+    type: "number",
+    default: "0",
+    desc: "Time offset in seconds from the form's base time. Used with loadNearest to determine which timestamp to fetch data for.",
+  },
+  {
+    name: "loadNearest",
+    type: "string",
+    default: "prev",
+    desc: "Strategy for auto-loading the nearest time series value. 'prev' loads the last value at or before the target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires a tsid and an office on the parent CWMSForm.",
+  },
+  {
     name: "units",
     type: "string",
     default: "EN",
@@ -182,6 +194,53 @@ import { CWMSForm } from "@usace-watermanagement/groundwork-water";
     placeholder="Enter flow value"
     precision={0}
     units="cfs"
+  />
+</CWMSForm>`}
+      </CodeBlock>
+
+      <Divider text="Load Nearest Value" className="mt-8" />
+      <Text className="mb-4">
+        When a <Code className="p-1">tsid</Code> is provided and the parent{" "}
+        <Code className="p-1">CWMSForm</Code> has an <Code className="p-1">office</Code>
+        , CWMSInput automatically fetches the nearest time series value and
+        pre-populates the input. The <Code className="p-1">loadNearest</Code> prop
+        controls the strategy:
+      </Text>
+      <ul className="list-disc ml-6 mb-4">
+        <li>
+          <Code className="p-1">prev</Code> (default) — last value at or before the
+          target time
+        </li>
+        <li>
+          <Code className="p-1">next</Code> — first value at or after the target time
+        </li>
+        <li>
+          <Code className="p-1">nearest</Code> — closest value by absolute time
+          difference
+        </li>
+      </ul>
+      <Text className="mb-4">
+        The input shows a Loading placeholder while fetching. Once loaded, the value
+        fills in automatically. If the user edits the field, the loaded value will not
+        overwrite their input. Changing the calendar date resets the loaded values.
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`<CWMSForm
+  office="SWT"
+  cdaUrl="https://cwms-data.usace.army.mil/cwms-data"
+  showCalendar={true}
+  calendarInterval="hour"
+>
+  <CWMSInput
+    name="stage-input"
+    tsid="KEYS.Elev.Inst.1Hour.0.Ccp-Rev"
+    type="number"
+    placeholder="Enter stage value"
+    precision={2}
+    units="ft"
+    loadNearest="prev"
+    timeOffset={0}
   />
 </CWMSForm>`}
       </CodeBlock>

--- a/docs/src/pages/docs/forms/cwms-input.jsx
+++ b/docs/src/pages/docs/forms/cwms-input.jsx
@@ -67,6 +67,12 @@ const componentProps = [
     desc: "Strategy for auto-loading the nearest time series value. 'prev' loads the last value at or before the target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires a tsid and an office on the parent CWMSForm.",
   },
   {
+    name: "showValueTimestamp",
+    type: "boolean",
+    default: "false",
+    desc: "When true, shows the source datetime of the loaded nearest value as a tooltip on the input. The tooltip is removed when the user edits the value.",
+  },
+  {
     name: "units",
     type: "string",
     default: "EN",

--- a/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
+++ b/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
@@ -109,6 +109,12 @@ const componentProps = [
     desc: "Strategy for auto-loading the nearest time series values into cells. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
   },
   {
+    name: "showValueTimestamp",
+    type: "boolean",
+    default: "false",
+    desc: "When true, shows the source datetime of the loaded nearest value as a tooltip on each cell. The tooltip is removed when the user edits the cell.",
+  },
+  {
     name: "className",
     type: "string",
     default: "undefined",

--- a/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
+++ b/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
@@ -105,8 +105,8 @@ const componentProps = [
   {
     name: "loadNearest",
     type: "string",
-    default: "prev",
-    desc: "Strategy for auto-loading the nearest time series values into cells. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
+    default: "undefined (feature off)",
+    desc: "Opt-in strategy for auto-loading the nearest time series values into cells. When omitted, no values are fetched. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
   },
   {
     name: "showValueTimestamp",
@@ -410,16 +410,17 @@ function CWMSSpreadsheetDocs() {
 
       <Divider text="Load Nearest Values" className="mt-8" />
       <Text className="mb-4">
-        When columns have a <Code className="p-1">tsid</Code> and the parent{" "}
+        This is an opt-in feature. When the <Code className="p-1">loadNearest</Code>{" "}
+        prop is set (and columns have a <Code className="p-1">tsid</Code> and the parent{" "}
         <Code className="p-1">CWMSForm</Code> provides an{" "}
-        <Code className="p-1">office</Code>, the spreadsheet automatically fetches the
-        nearest time series values and pre-populates cells. The{" "}
-        <Code className="p-1">loadNearest</Code> prop controls the strategy:
+        <Code className="p-1">office</Code>), the spreadsheet fetches the nearest time
+        series values and pre-populates cells. With{" "}
+        <Code className="p-1">loadNearest</Code> omitted, no values are fetched. The
+        prop value selects the strategy:
       </Text>
       <ul className="list-disc ml-6 mb-4">
         <li>
-          <Code className="p-1">prev</Code> (default) — last value at or before each
-          target time
+          <Code className="p-1">prev</Code> — last value at or before each target time
         </li>
         <li>
           <Code className="p-1">next</Code> — first value at or after each target time

--- a/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
+++ b/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
@@ -106,7 +106,7 @@ const componentProps = [
     name: "loadNearest",
     type: "string",
     default: "prev",
-    desc: "Load nearest value strategy (prev, next, nearest).",
+    desc: "Strategy for auto-loading the nearest time series values into cells. 'prev' loads the last value at or before each target time, 'next' loads the first value at or after, 'nearest' loads the closest by absolute time difference. Requires columns with tsid, timeoffsets, and an office on the parent CWMSForm.",
   },
   {
     name: "className",
@@ -401,6 +401,60 @@ function CWMSSpreadsheetDocs() {
         <li>The number of rows should match the length of the timeoffsets array</li>
         <li>Each row's data is submitted with its corresponding time offset</li>
       </ul>
+
+      <Divider text="Load Nearest Values" className="mt-8" />
+      <Text className="mb-4">
+        When columns have a <Code className="p-1">tsid</Code> and the parent{" "}
+        <Code className="p-1">CWMSForm</Code> provides an{" "}
+        <Code className="p-1">office</Code>, the spreadsheet automatically fetches the
+        nearest time series values and pre-populates cells. The{" "}
+        <Code className="p-1">loadNearest</Code> prop controls the strategy:
+      </Text>
+      <ul className="list-disc ml-6 mb-4">
+        <li>
+          <Code className="p-1">prev</Code> (default) — last value at or before each
+          target time
+        </li>
+        <li>
+          <Code className="p-1">next</Code> — first value at or after each target time
+        </li>
+        <li>
+          <Code className="p-1">nearest</Code> — closest value by absolute time
+          difference
+        </li>
+      </ul>
+      <Text className="mb-4">
+        Cells show a Loading placeholder while data is being fetched. Once a user edits
+        a cell, the loaded value will not overwrite their input. Changing the calendar
+        date resets the loaded values.
+      </Text>
+
+      <CodeBlock language="jsx">
+        {`// Auto-populate cells with the most recent time series values
+<CWMSForm office="SWT" cdaUrl="https://cwms-data.usace.army.mil/cwms-data" showCalendar={true}>
+  <CWMSSpreadsheet
+    columns={[
+      {
+        label: "Stage (ft)",
+        type: "number",
+        tsid: "KEYS.Elev.Inst.1Hour.0.Ccp-Rev",
+        units: "ft",
+        precision: 2
+      },
+      {
+        label: "Flow (cfs)",
+        type: "number",
+        tsid: "KEYS.Flow.Inst.1Hour.0.Ccp-Rev",
+        units: "cfs",
+        precision: 0
+      }
+    ]}
+    timeoffsets={[0, 3600, 7200, 10800]}
+    rows={4}
+    loadNearest="prev"
+  />
+</CWMSForm>`}
+      </CodeBlock>
 
       <Divider text="With Form Integration" className="mt-8" />
       <Text className="mb-4">

--- a/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
+++ b/docs/src/pages/docs/forms/cwms-spreadsheet.jsx
@@ -46,7 +46,7 @@ const componentProps = [
     name: "timeoffsets",
     type: "array",
     default: "[]",
-    desc: "Array of time offsets in seconds from the base time. Each offset corresponds to a row. When provided, automatically enables showTimestamps.",
+    desc: "Row definitions, one per row. Each entry is either a time offset in seconds from the base time, or an object { offset, id, label, loadNearest, disabled, readonly } overriding those settings for that row. The two forms can be mixed. When provided, automatically enables showTimestamps.",
   },
   {
     name: "precision",
@@ -101,6 +101,18 @@ const componentProps = [
     type: "boolean",
     default: "true",
     desc: "Whether to allow missing data in submissions.",
+  },
+  {
+    name: "highlightChanged",
+    type: "boolean",
+    default: "true",
+    desc: "When values have been loaded, dims cells still showing the loaded value and emboldens ones the operator has changed. Has no effect on cells nothing was loaded for.",
+  },
+  {
+    name: "cellClassName",
+    type: "function",
+    default: "undefined",
+    desc: "Called per cell with its status - { value, loadedValue, defaultValue, baseline, loaded, changed, prefilled, key, tsid, offset, column, row } - and whatever it returns is applied as a class on the cell.",
   },
   {
     name: "loadNearest",

--- a/lib/components/data/forms/CWMSForm.jsx
+++ b/lib/components/data/forms/CWMSForm.jsx
@@ -340,7 +340,14 @@ export function CWMSForm({
     <>
       <EnsureToastContainer containerId={containerId} />
       <FormContext.Provider
-        value={{ registerInput, baseTimestamp, getTimestampForInput, containerId }}
+        value={{
+          registerInput,
+          baseTimestamp,
+          getTimestampForInput,
+          containerId,
+          office,
+          cdaUrl,
+        }}
       >
         <form onSubmit={handleSubmit} className={formClasses} style={style}>
           {showCalendar && (

--- a/lib/components/data/forms/CWMSForm.jsx
+++ b/lib/components/data/forms/CWMSForm.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useRef, useState, useMemo } from "react";
+import React, { useRef, useState, useMemo, useCallback } from "react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc.js";
 import timezone from "dayjs/plugin/timezone.js";
@@ -6,6 +6,8 @@ import { Input, Field, Label, Button } from "@usace/groundwork";
 import { useAuth } from "../utilities/auth/useAuth";
 import { snapDayjs } from "./helpers/timeSnapping";
 import { useCwmsFormSubmit, useFormValidation } from "./hooks/useCwmsFormSubmit";
+import { useNearestValueStore } from "./hooks/useNearestValueStore";
+import { FormContext } from "./FormContext";
 
 import {
   showSuccessToast,
@@ -18,7 +20,7 @@ import { EnsureToastContainer } from "./helpers/ToastProvider";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
-export const FormContext = createContext();
+export { FormContext };
 
 // Counter to generate unique IDs for each form instance
 let formInstanceCounter = 0;
@@ -207,29 +209,46 @@ export function CWMSForm({
     };
   };
 
-  const getTimestampForInput = (timeOffset = 0) => {
-    // Parse the baseTimestamp (which is in datetime-local format) in the correct timezone
-    const base = parseDisplayValue(baseTimestamp);
+  // Memoized so downstream memos can depend on its identity rather than
+  // re-deriving target timestamps on every render of the form.
+  const getTimestampForInput = useCallback(
+    (timeOffset = 0) => {
+      // Parse the baseTimestamp (which is in datetime-local format) in the correct timezone
+      const base = parseDisplayValue(baseTimestamp);
 
-    if (timeOffset !== 0) {
-      // CWMSInputTable uses seconds, other components use minutes
-      // Simple heuristic: if the absolute value is >= 60, it's likely seconds
-      // This handles common cases like 3600 (1 hour), 7200 (2 hours), etc.
-      // For smaller values (0-59), treat as minutes for backward compatibility
-      let offsetMs;
+      if (timeOffset !== 0) {
+        // CWMSInputTable uses seconds, other components use minutes
+        // Simple heuristic: if the absolute value is >= 60, it's likely seconds
+        // This handles common cases like 3600 (1 hour), 7200 (2 hours), etc.
+        // For smaller values (0-59), treat as minutes for backward compatibility
+        let offsetMs;
 
-      if (Math.abs(timeOffset) >= 60) {
-        // Treat as seconds (from CWMSInputTable)
-        offsetMs = timeOffset * 1000;
-      } else {
-        // Treat as minutes (from other components)
-        offsetMs = timeOffset * 60 * 1000;
+        if (Math.abs(timeOffset) >= 60) {
+          // Treat as seconds (from CWMSInputTable)
+          offsetMs = timeOffset * 1000;
+        } else {
+          // Treat as minutes (from other components)
+          offsetMs = timeOffset * 60 * 1000;
+        }
+
+        base.setTime(base.getTime() + offsetMs);
       }
+      return base.toISOString();
+    },
+    // parseDisplayValue is derived from calendarTimezone; baseTimestamp is the
+    // only other input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [baseTimestamp, calendarTimezone],
+  );
 
-      base.setTime(base.getTime() + offsetMs);
-    }
-    return base.toISOString();
-  };
+  // Form-level orchestrator: collects every input's nearest-value need and
+  // issues one request per distinct tsid+units for the whole form.
+  const nearestValues = useNearestValueStore({
+    office,
+    cdaUrl,
+    getTimestampForInput,
+    baseTimestamp,
+  });
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -347,6 +366,7 @@ export function CWMSForm({
           containerId,
           office,
           cdaUrl,
+          nearestValues,
         }}
       >
         <form onSubmit={handleSubmit} className={formClasses} style={style}>

--- a/lib/components/data/forms/CWMSForm.jsx
+++ b/lib/components/data/forms/CWMSForm.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo, useCallback } from "react";
+import React, { useRef, useState, useMemo, useCallback, useEffect } from "react";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc.js";
 import timezone from "dayjs/plugin/timezone.js";
@@ -53,6 +53,7 @@ export function CWMSForm({
 }) {
   const inputsRef = useRef([]);
   const registeredIds = useRef(new Set());
+  const nearestValuesRef = useRef(null);
 
   // Generate a unique container ID for this form instance
   const containerId = useMemo(() => {
@@ -75,6 +76,18 @@ export function CWMSForm({
     auth,
     storeRule,
     onSuccess: (data) => {
+      // Hand what we just wrote to the nearest-value store before anything
+      // re-reads. CDA caches time series responses for several minutes, so the
+      // refetch this submission triggers can return the pre-submit value; the
+      // seeded points keep the operator looking at their own entry until CDA
+      // reports it back. Accessed via ref because the store is created further
+      // down this component.
+      if (data?.results?.length) {
+        nearestValuesRef.current?.seedSubmittedValues(
+          data.results.filter((result) => result.tsid),
+        );
+      }
+
       // Show success toast
       const message = formatSubmissionMessage(data);
       showSuccessToast(message, { autoClose: toastAutoClose, containerId });
@@ -249,6 +262,10 @@ export function CWMSForm({
     getTimestampForInput,
     baseTimestamp,
   });
+
+  useEffect(() => {
+    nearestValuesRef.current = nearestValues;
+  }, [nearestValues]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/lib/components/data/forms/CWMSForm.jsx
+++ b/lib/components/data/forms/CWMSForm.jsx
@@ -46,6 +46,7 @@ export function CWMSForm({
   calendarOffset = 0, // Offset in seconds applied to the snap anchor (e.g. 25200 for 7hrs, 600 for 10min)
   calendarUseGmtOffset = false, // When true, snap/store uses fixed GMT+offset even if calendarTimezone is set for display
   onCalendarChange, // Optional callback fired when the calendar timestamp changes. Receives the snapped Date object.
+  onLoadError, // Optional callback fired when loading nearest values fails. Receives the error.
   toastAutoClose = 5000, // Set to false to disable auto-close for all toasts, or number for milliseconds
   className = "",
   style,
@@ -266,6 +267,17 @@ export function CWMSForm({
   useEffect(() => {
     nearestValuesRef.current = nearestValues;
   }, [nearestValues]);
+
+  // A failed or timed-out load leaves fields empty, which is indistinguishable
+  // from "no data exists" - so hand the error to the caller rather than letting
+  // it pass silently.
+  const loadError = nearestValues.error;
+  useEffect(() => {
+    if (loadError && onLoadError) onLoadError(loadError);
+    // onLoadError is caller-supplied and often inline; keying on the error
+    // alone avoids re-firing for the same failure on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadError]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/lib/components/data/forms/FormContext.js
+++ b/lib/components/data/forms/FormContext.js
@@ -1,0 +1,15 @@
+import { createContext } from "react";
+
+/**
+ * Shared context for CWMSForm and its inputs.
+ *
+ * Lives in its own module so hooks that inputs consume (e.g. the nearest-value
+ * orchestrator) can read the context without importing CWMSForm, which would
+ * create a circular import.
+ *
+ * Re-exported from CWMSForm for backwards compatibility - `import { FormContext }
+ * from "../CWMSForm"` keeps working.
+ */
+export const FormContext = createContext();
+
+export default FormContext;

--- a/lib/components/data/forms/__tests__/CWMSForm.loadError.test.jsx
+++ b/lib/components/data/forms/__tests__/CWMSForm.loadError.test.jsx
@@ -1,0 +1,90 @@
+import { render } from "@testing-library/react";
+import { CWMSForm } from "../CWMSForm";
+import { useNearestValueStore } from "../hooks/useNearestValueStore";
+import { useCwmsFormSubmit } from "../hooks/useCwmsFormSubmit";
+
+vi.mock("../hooks/useNearestValueStore", () => ({
+  useNearestValueStore: vi.fn(),
+  useNearestValues: () => ({ values: {}, timestamps: {}, isPending: false }),
+}));
+
+vi.mock("../hooks/useCwmsFormSubmit", () => ({
+  useCwmsFormSubmit: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useFormValidation: () => ({ validateInputs: () => ({ isValid: true, errors: [] }) }),
+}));
+
+function mockStore({ error = null } = {}) {
+  useNearestValueStore.mockReturnValue({
+    registerDataNeed: () => () => {},
+    seedSubmittedValues: vi.fn(),
+    seriesByKey: {},
+    targetMsByOffset: {},
+    isPending: false,
+    error,
+  });
+}
+
+describe("CWMSForm nearest-value load errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCwmsFormSubmit.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  });
+
+  it("calls onLoadError when the shared fetch fails", () => {
+    const onLoadError = vi.fn();
+    const error = new Error("Request timed out");
+    mockStore({ error });
+
+    render(
+      <CWMSForm office="SWD" onLoadError={onLoadError}>
+        <div />
+      </CWMSForm>,
+    );
+
+    expect(onLoadError).toHaveBeenCalledWith(error);
+  });
+
+  it("does not call onLoadError when the fetch succeeds", () => {
+    const onLoadError = vi.fn();
+    mockStore({ error: null });
+
+    render(
+      <CWMSForm office="SWD" onLoadError={onLoadError}>
+        <div />
+      </CWMSForm>,
+    );
+
+    expect(onLoadError).not.toHaveBeenCalled();
+  });
+
+  it("fires once per failure rather than on every render", () => {
+    const onLoadError = vi.fn();
+    const error = new Error("Unauthorized");
+    mockStore({ error });
+
+    const { rerender } = render(
+      <CWMSForm office="SWD" onLoadError={onLoadError}>
+        <div />
+      </CWMSForm>,
+    );
+    rerender(
+      <CWMSForm office="SWD" onLoadError={onLoadError}>
+        <div />
+      </CWMSForm>,
+    );
+
+    expect(onLoadError).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders without an onLoadError handler", () => {
+    mockStore({ error: new Error("boom") });
+
+    expect(() =>
+      render(
+        <CWMSForm office="SWD">
+          <div />
+        </CWMSForm>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/lib/components/data/forms/hooks/__tests__/selectNearestValue.test.js
+++ b/lib/components/data/forms/hooks/__tests__/selectNearestValue.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { selectNearestValue } from "../useLoadNearestValues";
+
+const ts = (minutes) => minutes * 60 * 1000;
+
+const values = [
+  [ts(0), 10.0, 0],
+  [ts(60), 20.0, 0],
+  [ts(120), 30.0, 0],
+  [ts(180), 40.0, 0],
+  [ts(240), 50.0, 0],
+];
+
+describe("selectNearestValue", () => {
+  describe("prev strategy", () => {
+    it("selects the last value at or before the target", () => {
+      const result = selectNearestValue(values, ts(150), "prev");
+      expect(result).toEqual({ value: 30.0, timestamp: ts(120), qualityCode: 0 });
+    });
+
+    it("selects exact match", () => {
+      const result = selectNearestValue(values, ts(120), "prev");
+      expect(result).toEqual({ value: 30.0, timestamp: ts(120), qualityCode: 0 });
+    });
+
+    it("returns null when no value is at or before the target", () => {
+      const result = selectNearestValue(values, ts(-10), "prev");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("next strategy", () => {
+    it("selects the first value at or after the target", () => {
+      const result = selectNearestValue(values, ts(90), "next");
+      expect(result).toEqual({ value: 30.0, timestamp: ts(120), qualityCode: 0 });
+    });
+
+    it("selects exact match", () => {
+      const result = selectNearestValue(values, ts(60), "next");
+      expect(result).toEqual({ value: 20.0, timestamp: ts(60), qualityCode: 0 });
+    });
+
+    it("returns null when no value is at or after the target", () => {
+      const result = selectNearestValue(values, ts(300), "next");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("nearest strategy", () => {
+    it("selects the closest value by time", () => {
+      const result = selectNearestValue(values, ts(110), "nearest");
+      expect(result).toEqual({ value: 30.0, timestamp: ts(120), qualityCode: 0 });
+    });
+
+    it("selects exact match", () => {
+      const result = selectNearestValue(values, ts(180), "nearest");
+      expect(result).toEqual({ value: 40.0, timestamp: ts(180), qualityCode: 0 });
+    });
+
+    it("selects the closer of two equidistant values", () => {
+      const result = selectNearestValue(values, ts(90), "nearest");
+      expect(result.value).toBeDefined();
+      expect([ts(60), ts(120)]).toContain(result.timestamp);
+    });
+  });
+
+  describe("null handling", () => {
+    it("skips null values", () => {
+      const withNulls = [
+        [ts(0), 10.0, 0],
+        [ts(60), null, 0],
+        [ts(120), 30.0, 0],
+      ];
+      const result = selectNearestValue(withNulls, ts(60), "prev");
+      expect(result).toEqual({ value: 10.0, timestamp: ts(0), qualityCode: 0 });
+    });
+
+    it("returns null for all-null values", () => {
+      const allNull = [
+        [ts(0), null, 0],
+        [ts(60), null, 0],
+      ];
+      expect(selectNearestValue(allNull, ts(30), "prev")).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null for empty array", () => {
+      expect(selectNearestValue([], ts(0), "prev")).toBeNull();
+    });
+
+    it("returns null for undefined values", () => {
+      expect(selectNearestValue(undefined, ts(0), "prev")).toBeNull();
+    });
+
+    it("returns null for null values", () => {
+      expect(selectNearestValue(null, ts(0), "prev")).toBeNull();
+    });
+  });
+});

--- a/lib/components/data/forms/hooks/__tests__/useNearestValueStore.test.jsx
+++ b/lib/components/data/forms/hooks/__tests__/useNearestValueStore.test.jsx
@@ -1,0 +1,250 @@
+import { render } from "@testing-library/react";
+import { useCallback } from "react";
+import { FormContext } from "../../FormContext";
+import { useNearestValueStore, useNearestValues } from "../useNearestValueStore";
+import useCdaMultiTimeSeries from "../../../hooks/useCdaMultiTimeSeries";
+import useCdaCatalog from "../../../hooks/useCdaCatalog";
+
+vi.mock("../../../hooks/useCdaMultiTimeSeries", () => ({ default: vi.fn(() => []) }));
+vi.mock("../../../hooks/useCdaCatalog", () => ({ default: vi.fn() }));
+
+const FLOW = "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV";
+const ELEV = "LWG.Elev.Inst.1Hour.0.CBT-REV";
+
+const BASE_MS = Date.parse("2025-01-15T12:00:00Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Two points per series: one an hour before the base time, one at base time.
+const SERIES = {
+  [FLOW]: {
+    values: [
+      [BASE_MS - 3600 * 1000, 100.5, 0],
+      [BASE_MS, 101.5, 0],
+    ],
+  },
+  [ELEV]: {
+    values: [
+      [BASE_MS - 3600 * 1000, 735.1, 0],
+      [BASE_MS, 735.4, 0],
+    ],
+  },
+};
+
+let lastParams = [];
+
+function Harness({ children, office = "SWD" }) {
+  const getTimestampForInput = useCallback((offset = 0) => {
+    // Mirrors CWMSForm: offsets >= 60 are seconds.
+    const ms = Math.abs(offset) >= 60 ? offset * 1000 : offset * 60 * 1000;
+    return new Date(BASE_MS + ms).toISOString();
+  }, []);
+
+  const nearestValues = useNearestValueStore({
+    office,
+    cdaUrl: "http://cda.test",
+    getTimestampForInput,
+    baseTimestamp: "2025-01-15T12:00",
+  });
+
+  return (
+    <FormContext.Provider
+      value={{
+        registerInput: () => () => {},
+        getTimestampForInput,
+        office,
+        cdaUrl: "http://cda.test",
+        baseTimestamp: "2025-01-15T12:00",
+        nearestValues,
+      }}
+    >
+      {children}
+    </FormContext.Provider>
+  );
+}
+
+function Consumer({ columns, timeoffsets, strategy, onResult = () => {} }) {
+  const result = useNearestValues({ columns, timeoffsets, strategy });
+  onResult(result);
+  return null;
+}
+
+describe("useNearestValueStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastParams = [];
+    useCdaCatalog.mockReturnValue({ data: undefined, isPending: false, error: null });
+    useCdaMultiTimeSeries.mockImplementation(({ cdaParams }) => {
+      lastParams = cdaParams;
+      return cdaParams.map((param) => ({
+        isPending: false,
+        data: SERIES[param.name],
+        error: null,
+      }));
+    });
+  });
+
+  it("issues one request per distinct tsid even when components overlap", () => {
+    render(
+      <Harness>
+        {/* Both tables want FLOW; only the second wants ELEV. */}
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+        <Consumer
+          columns={[
+            { tsid: FLOW, units: "EN" },
+            { tsid: ELEV, units: "EN" },
+          ]}
+          timeoffsets={[0]}
+        />
+      </Harness>,
+    );
+
+    expect(lastParams.map((p) => p.name).sort()).toEqual([ELEV, FLOW].sort());
+  });
+
+  it("covers the union of every registered offset in one window", () => {
+    render(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[7200]} />
+      </Harness>,
+    );
+
+    expect(lastParams).toHaveLength(1);
+    // "prev" for both, so the window ends at the latest target (base + 2h) and
+    // reaches a lookback window behind the earliest.
+    expect(Date.parse(lastParams[0].end)).toBe(BASE_MS + 7200 * 1000);
+    expect(Date.parse(lastParams[0].begin)).toBe(BASE_MS - DAY_MS);
+  });
+
+  it("does not fetch future data for the prev strategy", () => {
+    render(
+      <Harness>
+        <Consumer
+          columns={[{ tsid: FLOW, units: "EN" }]}
+          timeoffsets={[0]}
+          strategy="prev"
+        />
+      </Harness>,
+    );
+
+    expect(Date.parse(lastParams[0].end)).toBe(BASE_MS);
+  });
+
+  it("extends the window forward when any consumer needs next", () => {
+    render(
+      <Harness>
+        <Consumer
+          columns={[{ tsid: FLOW, units: "EN" }]}
+          timeoffsets={[0]}
+          strategy="prev"
+        />
+        <Consumer
+          columns={[{ tsid: ELEV, units: "EN" }]}
+          timeoffsets={[0]}
+          strategy="next"
+        />
+      </Harness>,
+    );
+
+    // A single shared window has to satisfy both strategies.
+    expect(Date.parse(lastParams[0].end)).toBe(BASE_MS + DAY_MS);
+    expect(Date.parse(lastParams[0].begin)).toBe(BASE_MS - DAY_MS);
+  });
+
+  it("requests an explicit page size so the window is not truncated", () => {
+    render(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+
+    expect(lastParams[0].pageSize).toBeGreaterThan(0);
+  });
+
+  it("keeps the same tsid in different units as separate series", () => {
+    render(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+        <Consumer columns={[{ tsid: FLOW, units: "SI" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+
+    expect(lastParams).toHaveLength(2);
+    expect(lastParams.map((p) => p.units).sort()).toEqual(["EN", "SI"]);
+  });
+
+  it("resolves each consumer's own strategy from the shared fetch", () => {
+    const prevResult = vi.fn();
+    const nextResult = vi.fn();
+
+    render(
+      <Harness>
+        <Consumer
+          columns={[{ tsid: FLOW, units: "EN" }]}
+          timeoffsets={[-3600]}
+          strategy="prev"
+          onResult={prevResult}
+        />
+        <Consumer
+          columns={[{ tsid: FLOW, units: "EN" }]}
+          timeoffsets={[-3600]}
+          strategy="next"
+          onResult={nextResult}
+        />
+      </Harness>,
+    );
+
+    // Target is base - 1h, which is an exact sample, so prev and next agree
+    // there; what matters is each consumer gets values back off one fetch.
+    const prev = prevResult.mock.calls.at(-1)[0];
+    const next = nextResult.mock.calls.at(-1)[0];
+    expect(prev.values[`${FLOW}_-3600`]).toBe(100.5);
+    expect(next.values[`${FLOW}_-3600`]).toBe(100.5);
+    expect(lastParams).toHaveLength(1);
+  });
+
+  it("does not fetch without an office", () => {
+    render(
+      <Harness office={null}>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+
+    expect(lastParams).toEqual([]);
+  });
+
+  it("drops a series from the plan once its last consumer unmounts", () => {
+    const { rerender } = render(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+        <Consumer columns={[{ tsid: ELEV, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+    expect(lastParams).toHaveLength(2);
+
+    rerender(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+    expect(lastParams.map((p) => p.name)).toEqual([FLOW]);
+  });
+
+  it("keeps a shared series while another consumer still needs it", () => {
+    const { rerender } = render(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+    expect(lastParams).toHaveLength(1);
+
+    rerender(
+      <Harness>
+        <Consumer columns={[{ tsid: FLOW, units: "EN" }]} timeoffsets={[0]} />
+      </Harness>,
+    );
+    // Refcounted: the identical need is still registered once.
+    expect(lastParams.map((p) => p.name)).toEqual([FLOW]);
+  });
+});

--- a/lib/components/data/forms/hooks/__tests__/useNearestValueStore.test.jsx
+++ b/lib/components/data/forms/hooks/__tests__/useNearestValueStore.test.jsx
@@ -1,7 +1,8 @@
-import { render } from "@testing-library/react";
-import { useCallback } from "react";
+import { render, act } from "@testing-library/react";
+import { useCallback, useContext } from "react";
 import { FormContext } from "../../FormContext";
 import { useNearestValueStore, useNearestValues } from "../useNearestValueStore";
+import { selectNearestValue } from "../useLoadNearestValues";
 import useCdaMultiTimeSeries from "../../../hooks/useCdaMultiTimeSeries";
 import useCdaCatalog from "../../../hooks/useCdaCatalog";
 
@@ -31,6 +32,11 @@ const SERIES = {
 };
 
 let lastParams = [];
+
+// Resolve what a "prev" lookup at `targetMs` sees in a (possibly seeded) series.
+function selectAt(series, targetMs) {
+  return selectNearestValue(series?.values, targetMs, "prev")?.value;
+}
 
 function Harness({ children, office = "SWD" }) {
   const getTimestampForInput = useCallback((offset = 0) => {
@@ -201,6 +207,107 @@ describe("useNearestValueStore", () => {
     expect(prev.values[`${FLOW}_-3600`]).toBe(100.5);
     expect(next.values[`${FLOW}_-3600`]).toBe(100.5);
     expect(lastParams).toHaveLength(1);
+  });
+
+  describe("submitted-value seeding", () => {
+    // Simulates CDA's response cache: the fetch keeps returning pre-submit data
+    // for a few minutes after a write.
+    function renderWithSeeder() {
+      const seen = { store: null, result: null };
+
+      function Seeder() {
+        seen.store = useContext(FormContext).nearestValues;
+        return null;
+      }
+
+      render(
+        <Harness>
+          <Seeder />
+          <Consumer
+            columns={[{ tsid: FLOW, units: "EN" }]}
+            timeoffsets={[0]}
+            onResult={(r) => {
+              seen.result = r;
+            }}
+          />
+        </Harness>,
+      );
+
+      return seen;
+    }
+
+    // The case this exists for: submitting over an existing value. CDA's cached
+    // response still reports the old number at that instant.
+    it("shows the submitted value while the cached fetch still reports the old one", () => {
+      const seen = renderWithSeeder();
+      expect(seen.result.values[`${FLOW}_0`]).toBe(101.5);
+
+      act(() => {
+        seen.store.seedSubmittedValues([
+          {
+            tsid: FLOW,
+            units: "EN",
+            value: 999.9,
+            timestamp: new Date(BASE_MS).toISOString(),
+          },
+        ]);
+      });
+
+      expect(seen.result.values[`${FLOW}_0`]).toBe(999.9);
+    });
+
+    it("shows a submitted value at an instant the series had no point for", () => {
+      const seen = renderWithSeeder();
+
+      act(() => {
+        seen.store.seedSubmittedValues([
+          {
+            tsid: FLOW,
+            units: "EN",
+            value: 42.5,
+            timestamp: new Date(BASE_MS - 1800 * 1000).toISOString(),
+          },
+        ]);
+      });
+
+      // Between the two fetched samples, so a "prev" lookup just after it finds
+      // the submitted value rather than the older sample.
+      expect(selectAt(seen.store.seriesByKey[`${FLOW}|EN`], BASE_MS - 60_000)).toBe(
+        42.5,
+      );
+    });
+
+    it("drops the seed once the fetch reports the same value", () => {
+      const seen = renderWithSeeder();
+
+      act(() => {
+        // Seeding what CDA already reports means its cache has caught up.
+        seen.store.seedSubmittedValues([
+          {
+            tsid: FLOW,
+            units: "EN",
+            value: 101.5,
+            timestamp: new Date(BASE_MS).toISOString(),
+          },
+        ]);
+      });
+
+      // Series is back to exactly what was fetched - no lingering seeded point.
+      expect(seen.store.seriesByKey[`${FLOW}|EN`].values).toEqual(SERIES[FLOW].values);
+    });
+
+    it("ignores entries without a usable timestamp or value", () => {
+      const seen = renderWithSeeder();
+
+      act(() => {
+        seen.store.seedSubmittedValues([
+          { tsid: FLOW, units: "EN", value: null, timestamp: "2025-01-15T12:00:00Z" },
+          { tsid: FLOW, units: "EN", value: 5, timestamp: "not-a-date" },
+        ]);
+      });
+
+      expect(seen.result.values[`${FLOW}_0`]).toBe(101.5);
+    });
   });
 
   it("does not fetch without an office", () => {

--- a/lib/components/data/forms/hooks/useCwmsFormSubmit.js
+++ b/lib/components/data/forms/hooks/useCwmsFormSubmit.js
@@ -138,6 +138,9 @@ export function useCwmsFormSubmit({
                     type: "numeric",
                     status: "success",
                     value: value,
+                    // Carried so callers can key the result back to the series
+                    // it was written to (a tsid is only unique per unit system).
+                    units: input.units || "EN",
                     timestamp: input.timestamp,
                   });
                 } else {
@@ -165,6 +168,7 @@ export function useCwmsFormSubmit({
                     type: "text",
                     status: "success",
                     value: rawValue,
+                    units: input.units || "EN",
                     timestamp: input.timestamp,
                   });
                 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -2,6 +2,8 @@ import { useMemo, useEffect, useState } from "react";
 import useCdaMultiTimeSeries from "../../hooks/useCdaMultiTimeSeries";
 import useCdaCatalog from "../../hooks/useCdaCatalog";
 
+const VALID_STRATEGIES = ["prev", "next", "nearest"];
+
 /**
  * Select the nearest value from a timeseries values array based on strategy.
  * @param {Array<[number, number|null, number]>} values - CDA timeseries values [timestamp_ms, value, qualityCode]
@@ -58,6 +60,10 @@ export default function useLoadNearestValues({
 }) {
   const shouldFetch =
     enabled && !!office && columns.length > 0 && timeoffsets.length > 0;
+
+  // Callers overload `loadNearest` as both the enable flag and the strategy, so a
+  // non-string value (e.g. `loadNearest={true}`) can arrive here. Fall back to "prev".
+  const resolvedStrategy = VALID_STRATEGIES.includes(strategy) ? strategy : "prev";
 
   const targetTimestamps = useMemo(() => {
     if (!getTimestampForInput) return {};
@@ -199,14 +205,21 @@ export default function useLoadNearestValues({
           return;
         }
         const targetMs = new Date(targetIso).getTime();
-        const selected = selectNearestValue(tsData.values, targetMs, strategy);
+        const selected = selectNearestValue(tsData.values, targetMs, resolvedStrategy);
         vals[key] = selected ? selected.value : null;
         ts[key] = selected ? selected.timestamp : null;
       });
     });
 
     return { values: vals, timestamps: ts };
-  }, [shouldFetch, columns, timeoffsets, targetTimestamps, strategy, tsResults]);
+  }, [
+    shouldFetch,
+    columns,
+    timeoffsets,
+    targetTimestamps,
+    resolvedStrategy,
+    tsResults,
+  ]);
 
   return { values, timestamps, isPending };
 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -93,7 +93,9 @@ export default function useLoadNearestValues({
         name: tsid,
         office,
         unit,
-        begin: date || defaultBegin,
+        begin: date
+          ? new Date(new Date(date).getTime() - DAY_MS).toISOString()
+          : defaultBegin,
         end: date || defaultEnd,
       };
     });
@@ -130,8 +132,9 @@ export default function useLoadNearestValues({
 
   const catalogLike = useMemo(() => {
     if (tsidsNeedingCatalog.length === 0) return null;
-    if (tsidsNeedingCatalog.length === 1) return tsidsNeedingCatalog[0];
-    return tsidsNeedingCatalog.join("|");
+    const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (tsidsNeedingCatalog.length === 1) return escape(tsidsNeedingCatalog[0]);
+    return tsidsNeedingCatalog.map(escape).join("|");
   }, [tsidsNeedingCatalog]);
 
   const catalogResult = useCdaCatalog({

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -98,7 +98,7 @@ export default function useLoadNearestValues({
       return {
         name: tsid,
         office,
-        unit,
+        units: unit,
         begin: date
           ? new Date(new Date(date).getTime() - DAY_MS).toISOString()
           : defaultBegin,

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -179,10 +179,11 @@ export default function useLoadNearestValues({
     return false;
   }, [shouldFetch, tsDone, tsidsNeedingCatalog, catalogResult.isPending]);
 
-  const values = useMemo(() => {
-    if (!shouldFetch) return {};
+  const { values, timestamps } = useMemo(() => {
+    if (!shouldFetch) return { values: {}, timestamps: {} };
 
-    const result = {};
+    const vals = {};
+    const ts = {};
     columns.forEach((column, colIndex) => {
       const tsData = tsResults[colIndex]?.data;
 
@@ -190,17 +191,19 @@ export default function useLoadNearestValues({
         const key = `${column.tsid}_${offset}`;
         const targetIso = targetTimestamps[offset];
         if (!targetIso || !tsData?.values) {
-          result[key] = null;
+          vals[key] = null;
+          ts[key] = null;
           return;
         }
         const targetMs = new Date(targetIso).getTime();
         const selected = selectNearestValue(tsData.values, targetMs, strategy);
-        result[key] = selected ? selected.value : null;
+        vals[key] = selected ? selected.value : null;
+        ts[key] = selected ? selected.timestamp : null;
       });
     });
 
-    return result;
+    return { values: vals, timestamps: ts };
   }, [shouldFetch, columns, timeoffsets, targetTimestamps, strategy, tsResults]);
 
-  return { values, isPending };
+  return { values, timestamps, isPending };
 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -1,0 +1,206 @@
+import { useMemo, useEffect, useState } from "react";
+import useCdaMultiTimeSeries from "../../hooks/useCdaMultiTimeSeries";
+import useCdaCatalog from "../../hooks/useCdaCatalog";
+
+/**
+ * Select the nearest value from a timeseries values array based on strategy.
+ * @param {Array<[number, number|null, number]>} values - CDA timeseries values [timestamp_ms, value, qualityCode]
+ * @param {number} targetMs - Target timestamp in milliseconds
+ * @param {string} strategy - "prev", "next", or "nearest"
+ * @returns {{ value: number, timestamp: number, qualityCode: number } | null}
+ */
+export function selectNearestValue(values, targetMs, strategy) {
+  if (!values || values.length === 0) return null;
+
+  const nonNull = values.filter((entry) => entry[1] !== null);
+  if (nonNull.length === 0) return null;
+
+  let best = null;
+
+  if (strategy === "prev") {
+    for (let i = nonNull.length - 1; i >= 0; i--) {
+      if (nonNull[i][0] <= targetMs) {
+        best = nonNull[i];
+        break;
+      }
+    }
+  } else if (strategy === "next") {
+    for (let i = 0; i < nonNull.length; i++) {
+      if (nonNull[i][0] >= targetMs) {
+        best = nonNull[i];
+        break;
+      }
+    }
+  } else {
+    let bestDiff = Infinity;
+    for (const entry of nonNull) {
+      const diff = Math.abs(entry[0] - targetMs);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = entry;
+      }
+    }
+  }
+
+  if (!best) return null;
+  return { value: best[1], timestamp: best[0], qualityCode: best[2] };
+}
+
+export default function useLoadNearestValues({
+  columns,
+  timeoffsets,
+  strategy = "prev",
+  getTimestampForInput,
+  office,
+  cdaUrl,
+  defaultUnits = "EN",
+  enabled = true,
+}) {
+  const shouldFetch =
+    enabled && !!office && columns.length > 0 && timeoffsets.length > 0;
+
+  const targetTimestamps = useMemo(() => {
+    if (!getTimestampForInput) return {};
+    const map = {};
+    timeoffsets.forEach((offset) => {
+      map[offset] = getTimestampForInput(offset);
+    });
+    return map;
+  }, [timeoffsets, getTimestampForInput]);
+
+  const [latestDates, setLatestDates] = useState({});
+
+  // Build a window around the user's selected datetime for the initial fetch.
+  // If no data exists in this window, the catalog extent fallback kicks in.
+  const tsParams = useMemo(() => {
+    if (!shouldFetch) return [];
+
+    const timestamps = timeoffsets.map((offset) => {
+      const iso = targetTimestamps[offset];
+      return iso ? new Date(iso).getTime() : Date.now();
+    });
+    const minTs = Math.min(...timestamps);
+    const maxTs = Math.max(...timestamps);
+    const DAY_MS = 24 * 60 * 60 * 1000;
+    const defaultBegin = new Date(minTs - DAY_MS).toISOString();
+    const defaultEnd = new Date(maxTs + DAY_MS).toISOString();
+
+    return columns.map((column) => {
+      const tsid = column.tsid;
+      const unit = column.units || defaultUnits;
+      const date = latestDates[tsid];
+      return {
+        name: tsid,
+        office,
+        unit,
+        begin: date || defaultBegin,
+        end: date || defaultEnd,
+      };
+    });
+  }, [
+    columns,
+    office,
+    defaultUnits,
+    shouldFetch,
+    latestDates,
+    timeoffsets,
+    targetTimestamps,
+  ]);
+
+  const tsResults = useCdaMultiTimeSeries({
+    cdaParams: tsParams,
+    cdaUrl,
+    queryOptions: { enabled: shouldFetch && tsParams.length > 0 },
+  });
+
+  const tsDone = tsResults.every((r) => !r.isPending);
+
+  // Identify TSIDs that returned no data and haven't been looked up in the catalog yet
+  const tsidsNeedingCatalog = useMemo(() => {
+    if (!tsDone) return [];
+    return columns
+      .filter((column, i) => {
+        if (latestDates[column.tsid]) return false;
+        const result = tsResults[i];
+        if (!result?.data?.values) return true;
+        return result.data.values.filter((e) => e[1] !== null).length === 0;
+      })
+      .map((column) => column.tsid);
+  }, [tsDone, tsResults, columns, latestDates]);
+
+  const catalogLike = useMemo(() => {
+    if (tsidsNeedingCatalog.length === 0) return null;
+    if (tsidsNeedingCatalog.length === 1) return tsidsNeedingCatalog[0];
+    return tsidsNeedingCatalog.join("|");
+  }, [tsidsNeedingCatalog]);
+
+  const catalogResult = useCdaCatalog({
+    cdaParams: {
+      dataset: "TIMESERIES",
+      office,
+      like: catalogLike || "",
+    },
+    cdaUrl,
+    queryOptions: {
+      enabled: shouldFetch && tsidsNeedingCatalog.length > 0 && !!catalogLike,
+    },
+  });
+
+  // Extract latestTime from catalog extents, matching useCdaLatestValue's approach.
+  // Setting latestDates triggers tsParams to recompute with begin/end pinned to
+  // the extent timestamp, causing useCdaMultiTimeSeries to re-fetch those TSIDs.
+  useEffect(() => {
+    if (!catalogResult.data?.entries) return;
+
+    const newDates = {};
+    for (const entry of catalogResult.data.entries) {
+      const name = entry.name;
+      if (!name || !tsidsNeedingCatalog.includes(name)) continue;
+      const latestTime = entry.extents?.[0]?.latestTime;
+      if (!latestTime) continue;
+      const latestTimeIso =
+        typeof latestTime === "string" ? latestTime : latestTime.toISOString();
+      newDates[name] = latestTimeIso;
+    }
+
+    if (Object.keys(newDates).length === 0) return;
+
+    setLatestDates((prev) => {
+      const merged = { ...prev, ...newDates };
+      if (JSON.stringify(merged) === JSON.stringify(prev)) return prev;
+      return merged;
+    });
+  }, [catalogResult.data, tsidsNeedingCatalog]);
+
+  const isPending = useMemo(() => {
+    if (!shouldFetch) return false;
+    if (!tsDone) return true;
+    if (tsidsNeedingCatalog.length > 0 && catalogResult.isPending) return true;
+    return false;
+  }, [shouldFetch, tsDone, tsidsNeedingCatalog, catalogResult.isPending]);
+
+  const values = useMemo(() => {
+    if (!shouldFetch) return {};
+
+    const result = {};
+    columns.forEach((column, colIndex) => {
+      const tsData = tsResults[colIndex]?.data;
+
+      timeoffsets.forEach((offset) => {
+        const key = `${column.tsid}_${offset}`;
+        const targetIso = targetTimestamps[offset];
+        if (!targetIso || !tsData?.values) {
+          result[key] = null;
+          return;
+        }
+        const targetMs = new Date(targetIso).getTime();
+        const selected = selectNearestValue(tsData.values, targetMs, strategy);
+        result[key] = selected ? selected.value : null;
+      });
+    });
+
+    return result;
+  }, [shouldFetch, columns, timeoffsets, targetTimestamps, strategy, tsResults]);
+
+  return { values, isPending };
+}

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -405,20 +405,34 @@ export function selectValuesForCells({
     if (!column?.tsid) return;
     const units = column.units || defaultUnits;
     const data = seriesByKey[seriesKey(column.tsid, units)];
+    // A column may pick its own strategy; the fetch is shared regardless.
+    const columnStrategy = resolveStrategy(column.loadNearest ?? strategy);
 
     timeoffsets.forEach((offset) => {
-      const key = `${column.tsid}_${offset}`;
+      const key = cellKeyFor(column, offset);
       const targetMs = targetMsByOffset[offset];
       if (!Number.isFinite(targetMs) || !data?.values) {
         values[key] = null;
         timestamps[key] = null;
         return;
       }
-      const selected = selectNearestValue(data.values, targetMs, strategy);
+      const selected = selectNearestValue(data.values, targetMs, columnStrategy);
       values[key] = selected ? selected.value : null;
       timestamps[key] = selected ? selected.timestamp : null;
     });
   });
 
   return { values, timestamps };
+}
+
+/**
+ * Identify a cell within a component.
+ *
+ * Defaults to tsid so existing callers are unaffected, but a column may set an
+ * `id` to claim its own identity. That is what lets two columns reference the
+ * same time series - a read-only "previous value" beside an editable entry
+ * field - without sharing one cell's state.
+ */
+export function cellKeyFor(column, offset) {
+  return `${column?.id ?? column?.tsid}_${offset}`;
 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -401,22 +401,26 @@ export function selectValuesForCells({
   const values = {};
   const timestamps = {};
 
+  const rows = normalizeRows(timeoffsets);
+
   columns.forEach((column) => {
     if (!column?.tsid) return;
     const units = column.units || defaultUnits;
     const data = seriesByKey[seriesKey(column.tsid, units)];
-    // A column may pick its own strategy; the fetch is shared regardless.
-    const columnStrategy = resolveStrategy(column.loadNearest ?? strategy);
 
-    timeoffsets.forEach((offset) => {
-      const key = cellKeyFor(column, offset);
-      const targetMs = targetMsByOffset[offset];
+    rows.forEach((row) => {
+      const key = cellKeyFor(column, row);
+      const targetMs = targetMsByOffset[row.offset];
       if (!Number.isFinite(targetMs) || !data?.values) {
         values[key] = null;
         timestamps[key] = null;
         return;
       }
-      const selected = selectNearestValue(data.values, targetMs, columnStrategy);
+      // A column or row may pick its own strategy; the fetch is shared anyway.
+      const cellStrategy = resolveStrategy(
+        resolveCellSetting(column, row, "loadNearest", strategy),
+      );
+      const selected = selectNearestValue(data.values, targetMs, cellStrategy);
       values[key] = selected ? selected.value : null;
       timestamps[key] = selected ? selected.timestamp : null;
     });
@@ -428,11 +432,32 @@ export function selectValuesForCells({
 /**
  * Identify a cell within a component.
  *
- * Defaults to tsid so existing callers are unaffected, but a column may set an
- * `id` to claim its own identity. That is what lets two columns reference the
- * same time series - a read-only "previous value" beside an editable entry
- * field - without sharing one cell's state.
+ * Defaults to tsid and the raw offset so existing callers are unaffected, but a
+ * column or a row may set an `id` to claim its own identity. That is what lets
+ * two of them reference the same series and instant - a read-only "previous
+ * value" beside an editable entry field - without sharing one cell's state.
  */
-export function cellKeyFor(column, offset) {
-  return `${column?.id ?? column?.tsid}_${offset}`;
+export function cellKeyFor(column, row) {
+  const rowPart =
+    typeof row === "object" && row !== null ? (row.id ?? row.offset) : row;
+  return `${column?.id ?? column?.tsid}_${rowPart}`;
+}
+
+/**
+ * Accept `timeoffsets` as either plain numbers or row objects, and return row
+ * specs. A row object may carry its own `id`, `loadNearest` and `disabled`,
+ * mirroring what a column can override.
+ */
+export function normalizeRows(timeoffsets = []) {
+  return timeoffsets.map((entry) =>
+    typeof entry === "object" && entry !== null ? entry : { offset: entry },
+  );
+}
+
+/**
+ * Resolve a setting for one cell. Most specific wins: column, then row, then
+ * the component-wide default.
+ */
+export function resolveCellSetting(column, row, key, fallback) {
+  return column?.[key] ?? row?.[key] ?? fallback;
 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -473,27 +473,34 @@ export function formatLoadedValue(raw, precision) {
 }
 
 /**
- * Describe one cell relative to the value that was loaded for it.
+ * Describe one cell relative to the value it started with.
  *
  * Deliberately derived by comparison rather than by tracking edits: typing the
- * same number back over a loaded value is not a change, and a tracked flag
- * would claim it was. `loaded` is false when nothing was fetched for the cell,
- * in which case there is no baseline and `changed` stays false.
+ * same number back is not a change, and a tracked flag would claim it was.
  *
- * @returns {{value: string, loadedValue: string|null, loaded: boolean,
- *   changed: boolean, prefilled: boolean}}
+ * The baseline is the caller-supplied default where there is one, otherwise the
+ * fetched value - a default takes precedence over loading, so a defaulted cell
+ * has never been touched by the operator even though its value differs from
+ * what CDA returned. Without either there is no baseline and `changed` stays
+ * false, since anything typed into an empty cell is simply its first value.
+ *
+ * @returns {{value: string, loadedValue: string|null, defaultValue: string|null,
+ *   baseline: string|null, loaded: boolean, changed: boolean, prefilled: boolean}}
  */
-export function getCellStatus({ value, loadedRaw, precision = 2 }) {
+export function getCellStatus({ value, loadedRaw, precision = 2, defaultValue }) {
   const loadedValue = formatLoadedValue(loadedRaw, precision);
-  const loaded = loadedValue !== null;
+  const hasDefault = defaultValue !== null && defaultValue !== undefined;
+  const baseline = hasDefault ? String(defaultValue) : loadedValue;
   const current = value ?? "";
-  const changed = loaded ? current !== loadedValue : false;
+  const changed = baseline !== null ? current !== baseline : false;
 
   return {
     value: current,
     loadedValue,
-    loaded,
+    defaultValue: hasDefault ? String(defaultValue) : null,
+    baseline,
+    loaded: loadedValue !== null,
     changed,
-    prefilled: loaded && !changed,
+    prefilled: baseline !== null && !changed,
   };
 }

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -94,6 +94,33 @@ export function selectNearestValue(values, targetMs, strategy) {
 }
 
 /**
+ * Merge locally-known points (e.g. values this form just submitted) into a
+ * fetched series.
+ *
+ * CDA caches time series responses for several minutes, so a read issued right
+ * after a write can hand back the pre-submit value. Seeding what we know we
+ * wrote means the operator sees their own submission immediately.
+ *
+ * A seed wins over a fetched point at the same instant. That case is precisely
+ * the one this exists for: submitting over an existing value leaves the cached
+ * response still reporting the old number at that timestamp. Once CDA reports
+ * the seeded value back, the caller is expected to drop the seed.
+ *
+ * @param {Array<[number, number|null, number]>} values - fetched values, ascending
+ * @param {Map<number, number|string>} seeds - timestamp_ms -> value
+ */
+export function mergeSeededValues(values = [], seeds) {
+  if (!seeds || seeds.size === 0) return values;
+
+  const kept = values.filter((entry) => !seeds.has(entry[0]));
+  const seeded = [];
+  seeds.forEach((value, ms) => seeded.push([ms, value, 0]));
+
+  // selectNearestValue walks the array in order, so keep it ascending.
+  return [...kept, ...seeded].sort((a, b) => a[0] - b[0]);
+}
+
+/**
  * Fetch the raw series needed to resolve nearest values.
  *
  * This is the shared data layer: it knows nothing about form fields, columns or

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -461,3 +461,39 @@ export function normalizeRows(timeoffsets = []) {
 export function resolveCellSetting(column, row, key, fallback) {
   return column?.[key] ?? row?.[key] ?? fallback;
 }
+
+/**
+ * Render a loaded value the way the input displays it, so comparisons are made
+ * on what the operator actually sees rather than on the raw float.
+ */
+export function formatLoadedValue(raw, precision) {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "number") return String(raw);
+  return parseFloat(raw.toFixed(precision)).toString();
+}
+
+/**
+ * Describe one cell relative to the value that was loaded for it.
+ *
+ * Deliberately derived by comparison rather than by tracking edits: typing the
+ * same number back over a loaded value is not a change, and a tracked flag
+ * would claim it was. `loaded` is false when nothing was fetched for the cell,
+ * in which case there is no baseline and `changed` stays false.
+ *
+ * @returns {{value: string, loadedValue: string|null, loaded: boolean,
+ *   changed: boolean, prefilled: boolean}}
+ */
+export function getCellStatus({ value, loadedRaw, precision = 2 }) {
+  const loadedValue = formatLoadedValue(loadedRaw, precision);
+  const loaded = loadedValue !== null;
+  const current = value ?? "";
+  const changed = loaded ? current !== loadedValue : false;
+
+  return {
+    value: current,
+    loadedValue,
+    loaded,
+    changed,
+    prefilled: loaded && !changed,
+  };
+}

--- a/lib/components/data/forms/hooks/useLoadNearestValues.js
+++ b/lib/components/data/forms/hooks/useLoadNearestValues.js
@@ -3,6 +3,51 @@ import useCdaMultiTimeSeries from "../../hooks/useCdaMultiTimeSeries";
 import useCdaCatalog from "../../hooks/useCdaCatalog";
 
 const VALID_STRATEGIES = ["prev", "next", "nearest"];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// CDA applies its own default page size when none is given, and pagination
+// truncates from `begin` forward. For the "prev" strategy the value we want is
+// the *last* one in the window, so a truncated page would silently hand back a
+// stale value. Ask for a page large enough that a realistic window fits.
+const DEFAULT_PAGE_SIZE = 5000;
+
+// Values for a given instant do not change minute to minute. Without this the
+// host app's QueryClient defaults decide, and an app that leaves
+// refetchOnWindowFocus on re-fetches every series each time the operator
+// alt-tabs back.
+const DEFAULT_STALE_TIME = 60 * 1000;
+
+/**
+ * Normalize a caller-supplied strategy.
+ *
+ * Callers overload `loadNearest` as both the enable flag and the strategy, so a
+ * non-string value (e.g. `loadNearest={true}`) can arrive here. Fall back to "prev".
+ */
+export function resolveStrategy(strategy) {
+  return VALID_STRATEGIES.includes(strategy) ? strategy : "prev";
+}
+
+/**
+ * Key a fetched series by TSID *and* units. The same TSID requested in
+ * different unit systems is a different series - merging them would hand back
+ * values in the wrong unit.
+ */
+export function seriesKey(tsid, units) {
+  return `${tsid}|${units}`;
+}
+
+/**
+ * Does this strategy need data before / after the target time? Used to trim the
+ * fetch window: "prev" never looks at future values, so fetching a day of them
+ * is pure waste.
+ */
+export function strategyNeedsPast(strategy) {
+  return strategy === "prev" || strategy === "nearest";
+}
+
+export function strategyNeedsFuture(strategy) {
+  return strategy === "next" || strategy === "nearest";
+}
 
 /**
  * Select the nearest value from a timeseries values array based on strategy.
@@ -48,6 +93,189 @@ export function selectNearestValue(values, targetMs, strategy) {
   return { value: best[1], timestamp: best[0], qualityCode: best[2] };
 }
 
+/**
+ * Fetch the raw series needed to resolve nearest values.
+ *
+ * This is the shared data layer: it knows nothing about form fields, columns or
+ * cells. Callers hand it a de-duplicated list of series plus the target times
+ * that need covering, and get back the fetched series keyed by tsid+units.
+ * Picking a value out of a series is `selectNearestValue`'s job, which keeps
+ * per-field strategies independent of the (shared) fetch.
+ *
+ * @param {Object} params
+ * @param {Array<{tsid: string, units: string}>} params.series - de-duplicated series to fetch
+ * @param {number[]} params.targetsMs - every target instant that must be covered
+ * @param {boolean} params.needsPast - include a lookback window before the earliest target
+ * @param {boolean} params.needsFuture - include a lookahead window after the latest target
+ */
+export function useNearestSeriesData({
+  series = [],
+  targetsMs = [],
+  needsPast = true,
+  needsFuture = false,
+  office,
+  cdaUrl,
+  lookbackMs = DAY_MS,
+  lookaheadMs = DAY_MS,
+  pageSize = DEFAULT_PAGE_SIZE,
+  staleTime = DEFAULT_STALE_TIME,
+  enabled = true,
+}) {
+  const shouldFetch = enabled && !!office && series.length > 0 && targetsMs.length > 0;
+
+  const [latestDates, setLatestDates] = useState({});
+
+  // Build a window around the caller's target instants. If no data exists in
+  // this window, the catalog extent fallback below kicks in.
+  const tsParams = useMemo(() => {
+    if (!shouldFetch) return [];
+
+    const minTs = Math.min(...targetsMs);
+    const maxTs = Math.max(...targetsMs);
+    const defaultBegin = new Date(needsPast ? minTs - lookbackMs : minTs).toISOString();
+    const defaultEnd = new Date(
+      needsFuture ? maxTs + lookaheadMs : maxTs,
+    ).toISOString();
+
+    return series.map(({ tsid, units }) => {
+      const date = latestDates[seriesKey(tsid, units)];
+      return {
+        name: tsid,
+        office,
+        units,
+        begin: date
+          ? new Date(new Date(date).getTime() - lookbackMs).toISOString()
+          : defaultBegin,
+        end: date || defaultEnd,
+        pageSize,
+      };
+    });
+  }, [
+    series,
+    targetsMs,
+    needsPast,
+    needsFuture,
+    lookbackMs,
+    lookaheadMs,
+    office,
+    pageSize,
+    shouldFetch,
+    latestDates,
+  ]);
+
+  const queryOptions = useMemo(
+    () => ({ enabled: shouldFetch && tsParams.length > 0, staleTime }),
+    [shouldFetch, tsParams.length, staleTime],
+  );
+
+  const tsResults = useCdaMultiTimeSeries({
+    cdaParams: tsParams,
+    cdaUrl,
+    queryOptions,
+  });
+
+  const tsDone = tsResults.every((r) => !r.isPending);
+
+  // Identify series that returned no data and haven't been looked up in the
+  // catalog yet.
+  const seriesNeedingCatalog = useMemo(() => {
+    if (!tsDone) return [];
+    return series.filter((entry, i) => {
+      if (latestDates[seriesKey(entry.tsid, entry.units)]) return false;
+      const result = tsResults[i];
+      if (!result?.data?.values) return true;
+      return result.data.values.filter((e) => e[1] !== null).length === 0;
+    });
+  }, [tsDone, tsResults, series, latestDates]);
+
+  const catalogLike = useMemo(() => {
+    if (seriesNeedingCatalog.length === 0) return null;
+    const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const tsids = [...new Set(seriesNeedingCatalog.map((s) => s.tsid))];
+    // Anchor the alternation so the catalog returns the requested names rather
+    // than everything they happen to be a substring of.
+    return `^(${tsids.map(escape).join("|")})$`;
+  }, [seriesNeedingCatalog]);
+
+  const catalogResult = useCdaCatalog({
+    cdaParams: {
+      dataset: "TIMESERIES",
+      office,
+      like: catalogLike || "",
+      pageSize: DEFAULT_PAGE_SIZE,
+    },
+    cdaUrl,
+    queryOptions: {
+      enabled: shouldFetch && seriesNeedingCatalog.length > 0 && !!catalogLike,
+      staleTime,
+    },
+  });
+
+  // Extract latestTime from catalog extents, matching useCdaLatestValue's approach.
+  // Setting latestDates triggers tsParams to recompute with begin/end pinned to
+  // the extent timestamp, causing useCdaMultiTimeSeries to re-fetch those series.
+  useEffect(() => {
+    if (!catalogResult.data?.entries) return;
+
+    const latestByTsid = {};
+    for (const entry of catalogResult.data.entries) {
+      const name = entry.name;
+      if (!name) continue;
+      const latestTime = entry.extents?.[0]?.latestTime;
+      if (!latestTime) continue;
+      // Need to check if latestTime is already a string because React Query's
+      // persister returns Date types as strings upon retrieval
+      latestByTsid[name] =
+        typeof latestTime === "string" ? latestTime : latestTime.toISOString();
+    }
+
+    const newDates = {};
+    for (const entry of seriesNeedingCatalog) {
+      const iso = latestByTsid[entry.tsid];
+      if (iso) newDates[seriesKey(entry.tsid, entry.units)] = iso;
+    }
+
+    if (Object.keys(newDates).length === 0) return;
+
+    setLatestDates((prev) => {
+      const merged = { ...prev, ...newDates };
+      if (JSON.stringify(merged) === JSON.stringify(prev)) return prev;
+      return merged;
+    });
+  }, [catalogResult.data, seriesNeedingCatalog]);
+
+  const isPending = useMemo(() => {
+    if (!shouldFetch) return false;
+    if (!tsDone) return true;
+    if (seriesNeedingCatalog.length > 0 && catalogResult.isPending) return true;
+    return false;
+  }, [shouldFetch, tsDone, seriesNeedingCatalog, catalogResult.isPending]);
+
+  // Surface failures. Without this a 401 or a bad TSID is indistinguishable
+  // from "no data exists" - the field just stays empty.
+  const error = useMemo(() => {
+    const failed = tsResults.find((r) => r.error);
+    return failed?.error ?? catalogResult.error ?? null;
+  }, [tsResults, catalogResult.error]);
+
+  const seriesByKey = useMemo(() => {
+    const map = {};
+    series.forEach((entry, i) => {
+      map[seriesKey(entry.tsid, entry.units)] = tsResults[i]?.data ?? null;
+    });
+    return map;
+  }, [series, tsResults]);
+
+  return { seriesByKey, isPending, isError: !!error, error };
+}
+
+/**
+ * Resolve nearest values for a set of columns x time offsets.
+ *
+ * Standalone form of the feature: it fetches only what this caller asked for.
+ * Inside a CWMSForm prefer `useNearestValues`, which routes the same request
+ * through the form-level orchestrator so overlapping components share one fetch.
+ */
 export default function useLoadNearestValues({
   columns,
   timeoffsets,
@@ -58,168 +286,112 @@ export default function useLoadNearestValues({
   defaultUnits = "EN",
   enabled = true,
 }) {
-  const shouldFetch =
-    enabled && !!office && columns.length > 0 && timeoffsets.length > 0;
+  const resolvedStrategy = resolveStrategy(strategy);
 
-  // Callers overload `loadNearest` as both the enable flag and the strategy, so a
-  // non-string value (e.g. `loadNearest={true}`) can arrive here. Fall back to "prev".
-  const resolvedStrategy = VALID_STRATEGIES.includes(strategy) ? strategy : "prev";
+  const series = useMemo(() => {
+    const seen = new Set();
+    const out = [];
+    (columns ?? []).forEach((column) => {
+      if (!column?.tsid) return;
+      const units = column.units || defaultUnits;
+      const key = seriesKey(column.tsid, units);
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ tsid: column.tsid, units });
+    });
+    return out;
+  }, [columns, defaultUnits]);
 
   const targetTimestamps = useMemo(() => {
     if (!getTimestampForInput) return {};
     const map = {};
-    timeoffsets.forEach((offset) => {
+    (timeoffsets ?? []).forEach((offset) => {
       map[offset] = getTimestampForInput(offset);
     });
     return map;
   }, [timeoffsets, getTimestampForInput]);
 
-  const [latestDates, setLatestDates] = useState({});
+  const targetsMs = useMemo(
+    () =>
+      Object.values(targetTimestamps)
+        .map((iso) => new Date(iso).getTime())
+        .filter((ms) => Number.isFinite(ms)),
+    [targetTimestamps],
+  );
 
-  // Build a window around the user's selected datetime for the initial fetch.
-  // If no data exists in this window, the catalog extent fallback kicks in.
-  const tsParams = useMemo(() => {
-    if (!shouldFetch) return [];
-
-    const timestamps = timeoffsets.map((offset) => {
-      const iso = targetTimestamps[offset];
-      return iso ? new Date(iso).getTime() : Date.now();
-    });
-    const minTs = Math.min(...timestamps);
-    const maxTs = Math.max(...timestamps);
-    const DAY_MS = 24 * 60 * 60 * 1000;
-    const defaultBegin = new Date(minTs - DAY_MS).toISOString();
-    const defaultEnd = new Date(maxTs + DAY_MS).toISOString();
-
-    return columns.map((column) => {
-      const tsid = column.tsid;
-      const unit = column.units || defaultUnits;
-      const date = latestDates[tsid];
-      return {
-        name: tsid,
-        office,
-        units: unit,
-        begin: date
-          ? new Date(new Date(date).getTime() - DAY_MS).toISOString()
-          : defaultBegin,
-        end: date || defaultEnd,
-      };
-    });
-  }, [
-    columns,
+  const { seriesByKey, isPending, error } = useNearestSeriesData({
+    series,
+    targetsMs,
+    needsPast: strategyNeedsPast(resolvedStrategy),
+    needsFuture: strategyNeedsFuture(resolvedStrategy),
     office,
-    defaultUnits,
-    shouldFetch,
-    latestDates,
-    timeoffsets,
-    targetTimestamps,
-  ]);
-
-  const tsResults = useCdaMultiTimeSeries({
-    cdaParams: tsParams,
     cdaUrl,
-    queryOptions: { enabled: shouldFetch && tsParams.length > 0 },
+    enabled,
   });
 
-  const tsDone = tsResults.every((r) => !r.isPending);
+  const { values, timestamps } = useMemo(
+    () =>
+      selectValuesForCells({
+        columns,
+        timeoffsets,
+        defaultUnits,
+        strategy: resolvedStrategy,
+        seriesByKey,
+        targetMsByOffset: Object.fromEntries(
+          Object.entries(targetTimestamps).map(([offset, iso]) => [
+            offset,
+            new Date(iso).getTime(),
+          ]),
+        ),
+      }),
+    [
+      columns,
+      timeoffsets,
+      defaultUnits,
+      resolvedStrategy,
+      seriesByKey,
+      targetTimestamps,
+    ],
+  );
 
-  // Identify TSIDs that returned no data and haven't been looked up in the catalog yet
-  const tsidsNeedingCatalog = useMemo(() => {
-    if (!tsDone) return [];
-    return columns
-      .filter((column, i) => {
-        if (latestDates[column.tsid]) return false;
-        const result = tsResults[i];
-        if (!result?.data?.values) return true;
-        return result.data.values.filter((e) => e[1] !== null).length === 0;
-      })
-      .map((column) => column.tsid);
-  }, [tsDone, tsResults, columns, latestDates]);
+  return { values, timestamps, isPending, error };
+}
 
-  const catalogLike = useMemo(() => {
-    if (tsidsNeedingCatalog.length === 0) return null;
-    const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    if (tsidsNeedingCatalog.length === 1) return escape(tsidsNeedingCatalog[0]);
-    return tsidsNeedingCatalog.map(escape).join("|");
-  }, [tsidsNeedingCatalog]);
+/**
+ * Project fetched series onto `${tsid}_${offset}` cell keys.
+ *
+ * Shared by the standalone hook and the orchestrator-backed one so both produce
+ * identical output for the same inputs.
+ */
+export function selectValuesForCells({
+  columns = [],
+  timeoffsets = [],
+  defaultUnits = "EN",
+  strategy = "prev",
+  seriesByKey = {},
+  targetMsByOffset = {},
+}) {
+  const values = {};
+  const timestamps = {};
 
-  const catalogResult = useCdaCatalog({
-    cdaParams: {
-      dataset: "TIMESERIES",
-      office,
-      like: catalogLike || "",
-    },
-    cdaUrl,
-    queryOptions: {
-      enabled: shouldFetch && tsidsNeedingCatalog.length > 0 && !!catalogLike,
-    },
+  columns.forEach((column) => {
+    if (!column?.tsid) return;
+    const units = column.units || defaultUnits;
+    const data = seriesByKey[seriesKey(column.tsid, units)];
+
+    timeoffsets.forEach((offset) => {
+      const key = `${column.tsid}_${offset}`;
+      const targetMs = targetMsByOffset[offset];
+      if (!Number.isFinite(targetMs) || !data?.values) {
+        values[key] = null;
+        timestamps[key] = null;
+        return;
+      }
+      const selected = selectNearestValue(data.values, targetMs, strategy);
+      values[key] = selected ? selected.value : null;
+      timestamps[key] = selected ? selected.timestamp : null;
+    });
   });
 
-  // Extract latestTime from catalog extents, matching useCdaLatestValue's approach.
-  // Setting latestDates triggers tsParams to recompute with begin/end pinned to
-  // the extent timestamp, causing useCdaMultiTimeSeries to re-fetch those TSIDs.
-  useEffect(() => {
-    if (!catalogResult.data?.entries) return;
-
-    const newDates = {};
-    for (const entry of catalogResult.data.entries) {
-      const name = entry.name;
-      if (!name || !tsidsNeedingCatalog.includes(name)) continue;
-      const latestTime = entry.extents?.[0]?.latestTime;
-      if (!latestTime) continue;
-      const latestTimeIso =
-        typeof latestTime === "string" ? latestTime : latestTime.toISOString();
-      newDates[name] = latestTimeIso;
-    }
-
-    if (Object.keys(newDates).length === 0) return;
-
-    setLatestDates((prev) => {
-      const merged = { ...prev, ...newDates };
-      if (JSON.stringify(merged) === JSON.stringify(prev)) return prev;
-      return merged;
-    });
-  }, [catalogResult.data, tsidsNeedingCatalog]);
-
-  const isPending = useMemo(() => {
-    if (!shouldFetch) return false;
-    if (!tsDone) return true;
-    if (tsidsNeedingCatalog.length > 0 && catalogResult.isPending) return true;
-    return false;
-  }, [shouldFetch, tsDone, tsidsNeedingCatalog, catalogResult.isPending]);
-
-  const { values, timestamps } = useMemo(() => {
-    if (!shouldFetch) return { values: {}, timestamps: {} };
-
-    const vals = {};
-    const ts = {};
-    columns.forEach((column, colIndex) => {
-      const tsData = tsResults[colIndex]?.data;
-
-      timeoffsets.forEach((offset) => {
-        const key = `${column.tsid}_${offset}`;
-        const targetIso = targetTimestamps[offset];
-        if (!targetIso || !tsData?.values) {
-          vals[key] = null;
-          ts[key] = null;
-          return;
-        }
-        const targetMs = new Date(targetIso).getTime();
-        const selected = selectNearestValue(tsData.values, targetMs, resolvedStrategy);
-        vals[key] = selected ? selected.value : null;
-        ts[key] = selected ? selected.timestamp : null;
-      });
-    });
-
-    return { values: vals, timestamps: ts };
-  }, [
-    shouldFetch,
-    columns,
-    timeoffsets,
-    targetTimestamps,
-    resolvedStrategy,
-    tsResults,
-  ]);
-
-  return { values, timestamps, isPending };
+  return { values, timestamps };
 }

--- a/lib/components/data/forms/hooks/useNearestValueStore.js
+++ b/lib/components/data/forms/hooks/useNearestValueStore.js
@@ -2,6 +2,8 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "r
 import { FormContext } from "../FormContext";
 import {
   mergeSeededValues,
+  normalizeRows,
+  resolveCellSetting,
   resolveStrategy,
   seriesKey,
   selectValuesForCells,
@@ -20,13 +22,18 @@ import {
 function buildSpecKey({ columns, timeoffsets, strategy, defaultUnits }) {
   const seen = new Set();
   const series = [];
-  // Columns may override the strategy individually. The fetch window has to
-  // satisfy all of them, so every strategy in play is recorded.
+  // Columns and rows may override the strategy individually. The fetch window
+  // has to satisfy all of them, so every strategy in play is recorded.
   const strategies = new Set();
+  const rows = normalizeRows(timeoffsets);
 
   (columns ?? []).forEach((column) => {
     if (!column?.tsid) return;
-    strategies.add(resolveStrategy(column.loadNearest ?? strategy));
+    rows.forEach((row) => {
+      strategies.add(
+        resolveStrategy(resolveCellSetting(column, row, "loadNearest", strategy)),
+      );
+    });
     const units = column.units || defaultUnits;
     const key = seriesKey(column.tsid, units);
     if (seen.has(key)) return;
@@ -34,7 +41,7 @@ function buildSpecKey({ columns, timeoffsets, strategy, defaultUnits }) {
     series.push({ tsid: column.tsid, units });
   });
 
-  const offsets = [...new Set(timeoffsets ?? [])].sort((a, b) => a - b);
+  const offsets = [...new Set(rows.map((row) => row.offset))].sort((a, b) => a - b);
   if (series.length === 0 || offsets.length === 0) return null;
 
   series.sort((a, b) =>

--- a/lib/components/data/forms/hooks/useNearestValueStore.js
+++ b/lib/components/data/forms/hooks/useNearestValueStore.js
@@ -20,8 +20,13 @@ import {
 function buildSpecKey({ columns, timeoffsets, strategy, defaultUnits }) {
   const seen = new Set();
   const series = [];
+  // Columns may override the strategy individually. The fetch window has to
+  // satisfy all of them, so every strategy in play is recorded.
+  const strategies = new Set();
+
   (columns ?? []).forEach((column) => {
     if (!column?.tsid) return;
+    strategies.add(resolveStrategy(column.loadNearest ?? strategy));
     const units = column.units || defaultUnits;
     const key = seriesKey(column.tsid, units);
     if (seen.has(key)) return;
@@ -35,7 +40,7 @@ function buildSpecKey({ columns, timeoffsets, strategy, defaultUnits }) {
   series.sort((a, b) =>
     seriesKey(a.tsid, a.units).localeCompare(seriesKey(b.tsid, b.units)),
   );
-  return JSON.stringify({ series, offsets, strategy });
+  return JSON.stringify({ series, offsets, strategies: [...strategies].sort() });
 }
 
 /**
@@ -101,8 +106,10 @@ export function useNearestValueStore({
       spec.offsets?.forEach((offset) => offsets.add(offset));
       // The window must satisfy every registered strategy: if any field wants
       // "next" we need future data, even if the rest only want "prev".
-      needsPast = needsPast || strategyNeedsPast(spec.strategy);
-      needsFuture = needsFuture || strategyNeedsFuture(spec.strategy);
+      spec.strategies?.forEach((entry) => {
+        needsPast = needsPast || strategyNeedsPast(entry);
+        needsFuture = needsFuture || strategyNeedsFuture(entry);
+      });
     }
 
     return {

--- a/lib/components/data/forms/hooks/useNearestValueStore.js
+++ b/lib/components/data/forms/hooks/useNearestValueStore.js
@@ -1,0 +1,233 @@
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { FormContext } from "../FormContext";
+import {
+  resolveStrategy,
+  seriesKey,
+  selectValuesForCells,
+  strategyNeedsFuture,
+  strategyNeedsPast,
+  useNearestSeriesData,
+} from "./useLoadNearestValues";
+
+/**
+ * Build the registration payload for a set of cells.
+ *
+ * Serialized to a string so identical needs from different components collapse
+ * to one registry entry, and so re-renders that produce an equal need don't
+ * churn the fetch plan.
+ */
+function buildSpecKey({ columns, timeoffsets, strategy, defaultUnits }) {
+  const seen = new Set();
+  const series = [];
+  (columns ?? []).forEach((column) => {
+    if (!column?.tsid) return;
+    const units = column.units || defaultUnits;
+    const key = seriesKey(column.tsid, units);
+    if (seen.has(key)) return;
+    seen.add(key);
+    series.push({ tsid: column.tsid, units });
+  });
+
+  const offsets = [...new Set(timeoffsets ?? [])].sort((a, b) => a - b);
+  if (series.length === 0 || offsets.length === 0) return null;
+
+  series.sort((a, b) =>
+    seriesKey(a.tsid, a.units).localeCompare(seriesKey(b.tsid, b.units)),
+  );
+  return JSON.stringify({ series, offsets, strategy });
+}
+
+/**
+ * Form-level orchestrator for nearest-value loading.
+ *
+ * Inputs declare what they need (`useNearestValues` below); this collects every
+ * declaration, unions them into a single fetch plan, and issues one request per
+ * distinct tsid+units - no matter how many components asked for it. Two tables
+ * that overlap on a TSID share one request instead of racing two.
+ *
+ * Called by CWMSForm; the returned object goes on FormContext.
+ */
+export function useNearestValueStore({
+  office,
+  cdaUrl,
+  getTimestampForInput,
+  baseTimestamp,
+}) {
+  // specKey -> refcount. A ref (not state) so registering doesn't itself force a
+  // render; `specVersion` is the render signal, bumped only when the set of
+  // distinct needs actually changes.
+  const needsRef = useRef(new Map());
+  const [specVersion, setSpecVersion] = useState(0);
+
+  const registerDataNeed = useCallback((specKey) => {
+    if (!specKey) return undefined;
+    const needs = needsRef.current;
+    const next = (needs.get(specKey) ?? 0) + 1;
+    needs.set(specKey, next);
+    // Only a brand new need changes the plan; a second claimant of an identical
+    // need is already covered by the request the first one triggered.
+    if (next === 1) setSpecVersion((v) => v + 1);
+
+    return () => {
+      const current = needsRef.current.get(specKey) ?? 0;
+      if (current <= 1) {
+        needsRef.current.delete(specKey);
+        setSpecVersion((v) => v + 1);
+      } else {
+        needsRef.current.set(specKey, current - 1);
+      }
+    };
+  }, []);
+
+  // Union every registered need into one plan. Reading a ref inside useMemo is
+  // safe here because specVersion changes exactly when the ref's contents do.
+  const plan = useMemo(() => {
+    const seriesMap = new Map();
+    const offsets = new Set();
+    let needsPast = false;
+    let needsFuture = false;
+
+    for (const specKey of needsRef.current.keys()) {
+      let spec;
+      try {
+        spec = JSON.parse(specKey);
+      } catch {
+        continue;
+      }
+      spec.series?.forEach((entry) => {
+        seriesMap.set(seriesKey(entry.tsid, entry.units), entry);
+      });
+      spec.offsets?.forEach((offset) => offsets.add(offset));
+      // The window must satisfy every registered strategy: if any field wants
+      // "next" we need future data, even if the rest only want "prev".
+      needsPast = needsPast || strategyNeedsPast(spec.strategy);
+      needsFuture = needsFuture || strategyNeedsFuture(spec.strategy);
+    }
+
+    return {
+      series: [...seriesMap.values()],
+      offsets: [...offsets].sort((a, b) => a - b),
+      needsPast,
+      needsFuture,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [specVersion]);
+
+  // Target instants for every offset any input cares about. Keyed by offset so
+  // consumers don't each have to call getTimestampForInput (which is not
+  // referentially stable) inside their own memos.
+  const targetMsByOffset = useMemo(() => {
+    if (!getTimestampForInput) return {};
+    const map = {};
+    plan.offsets.forEach((offset) => {
+      const ms = new Date(getTimestampForInput(offset)).getTime();
+      if (Number.isFinite(ms)) map[offset] = ms;
+    });
+    return map;
+    // baseTimestamp is what actually determines the output of
+    // getTimestampForInput; depending on it keeps this stable across renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [plan, baseTimestamp, getTimestampForInput]);
+
+  const targetsMs = useMemo(() => Object.values(targetMsByOffset), [targetMsByOffset]);
+
+  const { seriesByKey, isPending, error } = useNearestSeriesData({
+    series: plan.series,
+    targetsMs,
+    needsPast: plan.needsPast,
+    needsFuture: plan.needsFuture,
+    office,
+    cdaUrl,
+    enabled: plan.series.length > 0,
+  });
+
+  return useMemo(
+    () => ({
+      registerDataNeed,
+      seriesByKey,
+      targetMsByOffset,
+      isPending,
+      error,
+    }),
+    [registerDataNeed, seriesByKey, targetMsByOffset, isPending, error],
+  );
+}
+
+/**
+ * Declare that a component needs nearest values for a set of columns x offsets,
+ * and read the resolved values back.
+ *
+ * The component does no fetching of its own: it registers the need with the
+ * form-level store and reads its slice of the shared result. Returns the same
+ * shape as the standalone `useLoadNearestValues` so components can swap between
+ * them without changing how they consume the data.
+ *
+ * @returns {{values: Object, timestamps: Object, isPending: boolean, error: any}}
+ *   values/timestamps are keyed `${tsid}_${offset}`.
+ */
+export function useNearestValues({
+  columns = [],
+  timeoffsets = [],
+  strategy,
+  defaultUnits = "EN",
+  enabled = true,
+}) {
+  const context = useContext(FormContext) ?? {};
+  const store = context.nearestValues;
+  const resolvedStrategy = resolveStrategy(strategy);
+
+  const specKey = useMemo(() => {
+    if (!enabled) return null;
+    return buildSpecKey({
+      columns,
+      timeoffsets,
+      strategy: resolvedStrategy,
+      defaultUnits,
+    });
+  }, [columns, timeoffsets, resolvedStrategy, defaultUnits, enabled]);
+
+  const registerDataNeed = store?.registerDataNeed;
+
+  useEffect(() => {
+    if (!specKey || !registerDataNeed) return undefined;
+    return registerDataNeed(specKey);
+  }, [specKey, registerDataNeed]);
+
+  const seriesByKey = store?.seriesByKey;
+  const targetMsByOffset = store?.targetMsByOffset;
+
+  const { values, timestamps } = useMemo(() => {
+    if (!specKey || !seriesByKey) return { values: {}, timestamps: {} };
+    return selectValuesForCells({
+      columns,
+      timeoffsets,
+      defaultUnits,
+      strategy: resolvedStrategy,
+      seriesByKey,
+      targetMsByOffset,
+    });
+  }, [
+    specKey,
+    seriesByKey,
+    targetMsByOffset,
+    columns,
+    timeoffsets,
+    defaultUnits,
+    resolvedStrategy,
+  ]);
+
+  // Report pending only while *this* component's series are outstanding, so one
+  // slow series elsewhere in the form doesn't leave every table pulsing.
+  const isPending = useMemo(() => {
+    if (!specKey || !store?.isPending) return false;
+    if (!seriesByKey) return true;
+    const spec = JSON.parse(specKey);
+    return spec.series.some(
+      (entry) => seriesByKey[seriesKey(entry.tsid, entry.units)] == null,
+    );
+  }, [specKey, store?.isPending, seriesByKey]);
+
+  return { values, timestamps, isPending, error: store?.error ?? null };
+}
+
+export default useNearestValues;

--- a/lib/components/data/forms/hooks/useNearestValueStore.js
+++ b/lib/components/data/forms/hooks/useNearestValueStore.js
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { FormContext } from "../FormContext";
 import {
+  mergeSeededValues,
   resolveStrategy,
   seriesKey,
   selectValuesForCells,
@@ -141,15 +142,92 @@ export function useNearestValueStore({
     enabled: plan.series.length > 0,
   });
 
+  // Values this form has written, keyed seriesKey -> (timestamp_ms -> value).
+  // Held so a read issued straight after a submit doesn't show the operator a
+  // stale value from CDA's response cache.
+  const [seeds, setSeeds] = useState(() => new Map());
+
+  const seedSubmittedValues = useCallback((entries) => {
+    if (!entries?.length) return;
+
+    setSeeds((prev) => {
+      const next = new Map(prev);
+      let changed = false;
+
+      entries.forEach(({ tsid, units, timestamp, value }) => {
+        if (!tsid || value === null || value === undefined) return;
+        const ms = new Date(timestamp).getTime();
+        if (!Number.isFinite(ms)) return;
+
+        const key = seriesKey(tsid, units ?? "EN");
+        const forSeries = new Map(next.get(key) ?? []);
+        if (forSeries.get(ms) === value) return;
+        forSeries.set(ms, value);
+        next.set(key, forSeries);
+        changed = true;
+      });
+
+      return changed ? next : prev;
+    });
+  }, []);
+
+  // Drop a seed once CDA reports the same value at that instant - that is the
+  // signal its cache has caught up, and it keeps the map from growing without
+  // bound. A fetch that still reports a *different* value at that instant is
+  // stale, so the seed stays.
+  useEffect(() => {
+    if (seeds.size === 0) return;
+
+    let changed = false;
+    const next = new Map();
+
+    seeds.forEach((forSeries, key) => {
+      const fetched = seriesByKey[key];
+      if (!fetched?.values?.length) {
+        next.set(key, forSeries);
+        return;
+      }
+      const fetchedAt = new Map(fetched.values.map((entry) => [entry[0], entry[1]]));
+      const remaining = new Map();
+      forSeries.forEach((value, ms) => {
+        if (fetchedAt.has(ms) && fetchedAt.get(ms) === value) changed = true;
+        else remaining.set(ms, value);
+      });
+      if (remaining.size > 0) next.set(key, remaining);
+    });
+
+    if (changed) setSeeds(next);
+  }, [seriesByKey, seeds]);
+
+  const seededSeriesByKey = useMemo(() => {
+    if (seeds.size === 0) return seriesByKey;
+
+    const merged = { ...seriesByKey };
+    seeds.forEach((forSeries, key) => {
+      const fetched = merged[key];
+      const values = mergeSeededValues(fetched?.values ?? [], forSeries);
+      merged[key] = fetched ? { ...fetched, values } : { values };
+    });
+    return merged;
+  }, [seriesByKey, seeds]);
+
   return useMemo(
     () => ({
       registerDataNeed,
-      seriesByKey,
+      seedSubmittedValues,
+      seriesByKey: seededSeriesByKey,
       targetMsByOffset,
       isPending,
       error,
     }),
-    [registerDataNeed, seriesByKey, targetMsByOffset, isPending, error],
+    [
+      registerDataNeed,
+      seedSubmittedValues,
+      seededSeriesByKey,
+      targetMsByOffset,
+      isPending,
+      error,
+    ],
   );
 }
 

--- a/lib/components/data/forms/inputs/CWMSCheckboxes.jsx
+++ b/lib/components/data/forms/inputs/CWMSCheckboxes.jsx
@@ -21,6 +21,9 @@ function CWMSCheckboxes({
 
     if (registerInput) {
       content.forEach((item) => {
+        // Don't register disabled inputs for submission
+        if (item.disabled || item.disable) return;
+
         if (item.tsid) {
           const checkboxRef = {
             name: item.id || item.label,

--- a/lib/components/data/forms/inputs/CWMSFileUpload.jsx
+++ b/lib/components/data/forms/inputs/CWMSFileUpload.jsx
@@ -159,6 +159,9 @@ function CWMSFileUpload({
   useEffect(() => {
     if (!registerInput) return;
 
+    // Don't register disabled inputs for submission
+    if (disabled) return;
+
     const inputRef = {
       kind: "blob",
       name,
@@ -193,6 +196,7 @@ function CWMSFileUpload({
   }, [
     blobId,
     description,
+    disabled,
     encodedValue,
     failIfExists,
     mediaTypeId,

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -93,7 +93,10 @@ function CWMSInput({
       required: required || false,
       label: label || placeholder || inputProps.name,
       getValues: () => [inputValue],
-      reset: () => setInputValue(defaultValue || ""),
+      reset: () => {
+        userEdited.current = false;
+        setInputValue(defaultValue || "");
+      },
       setInvalid: setIsInvalid,
     };
 

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
+import useLoadNearestValues from "../hooks/useLoadNearestValues";
 
 function CWMSInput({
   // CWMS-specific props
@@ -29,9 +30,41 @@ function CWMSInput({
   // All other props to pass through
   ...inputProps
 }) {
-  const { registerInput } = useContext(FormContext);
+  const { registerInput, getTimestampForInput, office, cdaUrl, baseTimestamp } =
+    useContext(FormContext);
   const [inputValue, setInputValue] = useState(defaultValue || value || "");
   const [isInvalid, setIsInvalid] = useState(invalid || false);
+  const userEdited = useRef(false);
+
+  const columnsArr = useMemo(
+    () => (tsid ? [{ tsid, units: units || "EN" }] : []),
+    [tsid, units],
+  );
+  const timeoffsetsArr = useMemo(() => [timeOffset || 0], [timeOffset]);
+
+  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+    columns: columnsArr,
+    timeoffsets: timeoffsetsArr,
+    strategy: loadNearest || "prev",
+    getTimestampForInput,
+    office,
+    cdaUrl,
+    defaultUnits: units || "EN",
+    enabled: !!office && !!tsid,
+  });
+
+  useEffect(() => {
+    if (isLoadingNearest || !loadedValues) return;
+    const key = `${tsid}_${timeOffset || 0}`;
+    const val = loadedValues[key];
+    if (!userEdited.current && val != null && inputValue !== String(val)) {
+      setInputValue(String(val));
+    }
+  }, [loadedValues, isLoadingNearest, tsid, timeOffset, inputValue]);
+
+  useEffect(() => {
+    userEdited.current = false;
+  }, [baseTimestamp]);
 
   useEffect(() => {
     if (!registerInput) return;
@@ -82,8 +115,8 @@ function CWMSInput({
 
   const handleChange = (e) => {
     const newValue = e.target.value;
+    userEdited.current = true;
     setInputValue(newValue);
-    // Clear invalid state when user starts typing
     if (isInvalid && newValue) {
       setIsInvalid(false);
     }
@@ -91,6 +124,8 @@ function CWMSInput({
       onChange(newValue);
     }
   };
+
+  const cellLoading = isLoadingNearest && !inputValue;
 
   return (
     <Input
@@ -101,6 +136,8 @@ function CWMSInput({
       value={inputValue}
       onChange={handleChange}
       required={required}
+      placeholder={cellLoading ? "Loading..." : placeholder}
+      className={`${inputProps.className || ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
     />
   );
 }

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -132,6 +132,7 @@ function CWMSInput({
     const newValue = e.target.value;
     userEdited.current = true;
     setInputValue(newValue);
+    // Clear invalid state when user starts typing
     if (isInvalid && newValue) {
       setIsInvalid(false);
     }

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -64,7 +64,12 @@ function CWMSInput({
     if (isLoadingNearest || !loadedValues) return;
     const key = `${tsid}_${timeOffset || 0}`;
     const val = loadedValues[key];
-    if (!userEdited.current && val != null && inputValue !== String(val)) {
+    if (
+      !userEdited.current &&
+      !(defaultValue || value) &&
+      val != null &&
+      inputValue !== String(val)
+    ) {
       setInputValue(String(val));
     }
   }, [loadedValues, isLoadingNearest, tsid, timeOffset, inputValue]);

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -23,6 +23,9 @@ function CWMSInput({
   required,
   placeholder,
 
+  // Display options
+  showValueTimestamp,
+
   // Legacy prop names
   disable,
   readonly,
@@ -42,7 +45,11 @@ function CWMSInput({
   );
   const timeoffsetsArr = useMemo(() => [timeOffset || 0], [timeOffset]);
 
-  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+  const {
+    values: loadedValues,
+    timestamps: loadedTimestamps,
+    isPending: isLoadingNearest,
+  } = useLoadNearestValues({
     columns: columnsArr,
     timeoffsets: timeoffsetsArr,
     strategy: loadNearest || "prev",
@@ -126,6 +133,11 @@ function CWMSInput({
   };
 
   const cellLoading = isLoadingNearest && !inputValue;
+  const tsKey = `${tsid}_${timeOffset || 0}`;
+  const valueTs =
+    showValueTimestamp && !userEdited.current && loadedTimestamps?.[tsKey]
+      ? new Date(loadedTimestamps[tsKey]).toLocaleString("sv-SE").replace("T", " ")
+      : null;
 
   return (
     <Input
@@ -138,6 +150,7 @@ function CWMSInput({
       required={required}
       placeholder={cellLoading ? "Loading..." : placeholder}
       className={`${inputProps.className || ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
+      title={valueTs ? `Value from: ${valueTs}` : undefined}
     />
   );
 }

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -57,7 +57,7 @@ function CWMSInput({
     office,
     cdaUrl,
     defaultUnits: units || "EN",
-    enabled: !!office && !!tsid,
+    enabled: !!office && !!tsid && !!loadNearest,
   });
 
   useEffect(() => {

--- a/lib/components/data/forms/inputs/CWMSInput.jsx
+++ b/lib/components/data/forms/inputs/CWMSInput.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
-import useLoadNearestValues from "../hooks/useLoadNearestValues";
+import { useNearestValues } from "../hooks/useNearestValueStore";
 
 function CWMSInput({
   // CWMS-specific props
@@ -33,8 +33,7 @@ function CWMSInput({
   // All other props to pass through
   ...inputProps
 }) {
-  const { registerInput, getTimestampForInput, office, cdaUrl, baseTimestamp } =
-    useContext(FormContext);
+  const { registerInput, baseTimestamp } = useContext(FormContext);
   const [inputValue, setInputValue] = useState(defaultValue || value || "");
   const [isInvalid, setIsInvalid] = useState(invalid || false);
   const userEdited = useRef(false);
@@ -45,19 +44,18 @@ function CWMSInput({
   );
   const timeoffsetsArr = useMemo(() => [timeOffset || 0], [timeOffset]);
 
+  // Declares the need; the form-level store does the fetching and shares it
+  // with any other input asking for the same series.
   const {
     values: loadedValues,
     timestamps: loadedTimestamps,
     isPending: isLoadingNearest,
-  } = useLoadNearestValues({
+  } = useNearestValues({
     columns: columnsArr,
     timeoffsets: timeoffsetsArr,
     strategy: loadNearest || "prev",
-    getTimestampForInput,
-    office,
-    cdaUrl,
     defaultUnits: units || "EN",
-    enabled: !!office && !!tsid && !!loadNearest,
+    enabled: !!tsid && !!loadNearest,
   });
 
   useEffect(() => {

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -43,6 +43,7 @@ function CWMSInputTable({
   const [invalidCells, setInvalidCells] = useState({});
   const cleanupFunctions = useRef([]);
   const userEdited = useRef(new Set());
+  const loadedValuesRef = useRef({});
 
   const {
     values: loadedValues,
@@ -58,6 +59,10 @@ function CWMSInputTable({
     defaultUnits: units,
     enabled: !!office && columns.length > 0 && timeoffsets.length > 0,
   });
+
+  useEffect(() => {
+    if (loadedValues) loadedValuesRef.current = loadedValues;
+  }, [loadedValues]);
 
   useEffect(() => {
     if (isLoadingNearest || !loadedValues) return;
@@ -126,9 +131,16 @@ function CWMSInputTable({
           label: column.label || `${tsid} at ${offset}s`,
           getValues: () => [matrixData[key] || ""],
           reset: () => {
+            userEdited.current.delete(key);
+            const nearestRaw = loadedValuesRef.current[key];
+            let resetVal = columnDefaultValues[offset] || "";
+            if (nearestRaw != null) {
+              const p = columnPrecision ?? precision;
+              resetVal = parseFloat(nearestRaw.toFixed(p)).toString();
+            }
             setMatrixData((prev) => ({
               ...prev,
-              [key]: columnDefaultValues[offset] || "",
+              [key]: resetVal,
             }));
             setInvalidCells((prev) => ({
               ...prev,

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -56,22 +56,27 @@ function CWMSInputTable({
 
   useEffect(() => {
     if (isLoadingNearest || !loadedValues) return;
+    const precisionByTsid = {};
+    columns.forEach((col) => {
+      precisionByTsid[col.tsid] = col.precision ?? precision;
+    });
     setMatrixData((prev) => {
       const next = { ...prev };
       let changed = false;
       Object.entries(loadedValues).forEach(([key, value]) => {
-        if (
-          !userEdited.current.has(key) &&
-          value != null &&
-          next[key] !== String(value)
-        ) {
-          next[key] = String(value);
-          changed = true;
+        if (!userEdited.current.has(key) && value != null) {
+          const tsid = key.substring(0, key.lastIndexOf("_"));
+          const p = precisionByTsid[tsid] ?? precision;
+          const rounded = parseFloat(value.toFixed(p)).toString();
+          if (next[key] !== rounded) {
+            next[key] = rounded;
+            changed = true;
+          }
         }
       });
       return changed ? next : prev;
     });
-  }, [loadedValues, isLoadingNearest]);
+  }, [loadedValues, isLoadingNearest, columns, precision]);
 
   useEffect(() => {
     userEdited.current.clear();
@@ -226,7 +231,14 @@ function CWMSInputTable({
 
             return (
               <tr key={colIndex}>
-                <td className="p-2 font-medium">{column.label || column.tsid}</td>
+                <td className="p-2 font-medium">
+                  {column.label || column.tsid}
+                  {column.displayUnits && (
+                    <span className="ml-1 text-sm text-gray-500">
+                      ({column.displayUnits})
+                    </span>
+                  )}
+                </td>
                 {timeoffsets.map((offset, offsetIndex) => {
                   const key = `${column.tsid}_${offset}`;
                   const cellLoading = isLoadingNearest && !matrixData[key];
@@ -235,6 +247,7 @@ function CWMSInputTable({
                       <Input
                         name={key}
                         type="number"
+                        step={column.step}
                         value={matrixData[key] || ""}
                         onChange={(e) =>
                           handleInputChange(column.tsid, offset, e.target.value)
@@ -268,6 +281,11 @@ function CWMSInputTable({
           {columns.map((column, index) => (
             <th key={index} className="p-2 text-left border-b-2 border-gray-300">
               {column.label || column.tsid}
+              {column.displayUnits && (
+                <span className="ml-1 text-sm text-gray-500 font-normal">
+                  ({column.displayUnits})
+                </span>
+              )}
             </th>
           ))}
         </tr>
@@ -299,6 +317,7 @@ function CWMSInputTable({
                     <Input
                       name={key}
                       type="number"
+                      step={column.step}
                       value={matrixData[key] || ""}
                       onChange={(e) =>
                         handleInputChange(column.tsid, offset, e.target.value)

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext, useRef } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
+import useLoadNearestValues from "../hooks/useLoadNearestValues";
 
 function CWMSInputTable({
   className,
@@ -20,7 +21,8 @@ function CWMSInputTable({
   required = false,
   transpose = false,
 }) {
-  const { registerInput, getTimestampForInput } = useContext(FormContext);
+  const { registerInput, getTimestampForInput, office, cdaUrl, baseTimestamp } =
+    useContext(FormContext);
 
   // Initialize matrixData from column defaultValues
   const getInitialMatrixData = () => {
@@ -39,6 +41,41 @@ function CWMSInputTable({
   const [matrixData, setMatrixData] = useState(getInitialMatrixData);
   const [invalidCells, setInvalidCells] = useState({});
   const cleanupFunctions = useRef([]);
+  const userEdited = useRef(new Set());
+
+  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+    columns,
+    timeoffsets,
+    strategy: loadNearest,
+    getTimestampForInput,
+    office,
+    cdaUrl,
+    defaultUnits: units,
+    enabled: !!office && columns.length > 0 && timeoffsets.length > 0,
+  });
+
+  useEffect(() => {
+    if (isLoadingNearest || !loadedValues) return;
+    setMatrixData((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      Object.entries(loadedValues).forEach(([key, value]) => {
+        if (
+          !userEdited.current.has(key) &&
+          value != null &&
+          next[key] !== String(value)
+        ) {
+          next[key] = String(value);
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [loadedValues, isLoadingNearest]);
+
+  useEffect(() => {
+    userEdited.current.clear();
+  }, [baseTimestamp]);
 
   useEffect(() => {
     if (!registerInput) return;
@@ -125,6 +162,7 @@ function CWMSInputTable({
 
   const handleInputChange = (tsid, offset, value) => {
     const key = `${tsid}_${offset}`;
+    userEdited.current.add(key);
     const updatedData = {
       ...matrixData,
       [key]: value,
@@ -191,6 +229,7 @@ function CWMSInputTable({
                 <td className="p-2 font-medium">{column.label || column.tsid}</td>
                 {timeoffsets.map((offset, offsetIndex) => {
                   const key = `${column.tsid}_${offset}`;
+                  const cellLoading = isLoadingNearest && !matrixData[key];
                   return (
                     <td key={offsetIndex} className="p-2">
                       <Input
@@ -203,8 +242,8 @@ function CWMSInputTable({
                         disabled={disable}
                         readOnly={columnReadonly}
                         invalid={invalidCells[key] || invalid ? "true" : undefined}
-                        placeholder="Enter value"
-                        className={`w-full ${invalidCells[key] ? "border-red-500" : ""}`}
+                        placeholder={cellLoading ? "Loading..." : "Enter value"}
+                        className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
                         required={columnRequired}
                       />
                     </td>
@@ -253,6 +292,7 @@ function CWMSInputTable({
                 const key = `${column.tsid}_${offset}`;
                 const columnReadonly = column.readonly ?? readonly;
                 const columnRequired = column.required ?? required;
+                const cellLoading = isLoadingNearest && !matrixData[key];
 
                 return (
                   <td key={colIndex} className="p-2">
@@ -266,8 +306,8 @@ function CWMSInputTable({
                       disabled={disable}
                       readOnly={columnReadonly}
                       invalid={invalidCells[key] || invalid ? "true" : undefined}
-                      placeholder="Enter value"
-                      className={`w-full ${invalidCells[key] ? "border-red-500" : ""}`}
+                      placeholder={cellLoading ? "Loading..." : "Enter value"}
+                      className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
                       required={columnRequired}
                     />
                   </td>

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -140,9 +140,12 @@ function CWMSInputTable({
           getValues: () => [matrixData[key] || ""],
           reset: () => {
             userEdited.current.delete(key);
+            // Mirror the populate effect: a caller-supplied default takes
+            // precedence over the fetched nearest value.
+            const hasDefault = columnDefaultValues[offset] !== undefined;
             const nearestRaw = loadedValuesRef.current[key];
-            let resetVal = columnDefaultValues[offset] || "";
-            if (nearestRaw != null) {
+            let resetVal = hasDefault ? columnDefaultValues[offset] : "";
+            if (!hasDefault && nearestRaw != null) {
               const p = columnPrecision ?? precision;
               resetVal = parseFloat(nearestRaw.toFixed(p)).toString();
             }

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -73,8 +73,16 @@ function CWMSInputTable({
     setMatrixData((prev) => {
       const next = { ...prev };
       let changed = false;
+      const defaultKeys = new Set();
+      columns.forEach((col) => {
+        if (col.defaultValues) {
+          Object.keys(col.defaultValues).forEach((offset) => {
+            defaultKeys.add(`${col.tsid}_${offset}`);
+          });
+        }
+      });
       Object.entries(loadedValues).forEach(([key, value]) => {
-        if (!userEdited.current.has(key) && value != null) {
+        if (!userEdited.current.has(key) && !defaultKeys.has(key) && value != null) {
           const tsid = key.substring(0, key.lastIndexOf("_"));
           const p = precisionByTsid[tsid] ?? precision;
           const rounded = parseFloat(value.toFixed(p)).toString();

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -18,6 +18,7 @@ function CWMSInputTable({
   units = "EN",
   onChange,
   showTimestamps = true,
+  showValueTimestamp = false,
   required = false,
   transpose = false,
 }) {
@@ -43,7 +44,11 @@ function CWMSInputTable({
   const cleanupFunctions = useRef([]);
   const userEdited = useRef(new Set());
 
-  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+  const {
+    values: loadedValues,
+    timestamps: loadedTimestamps,
+    isPending: isLoadingNearest,
+  } = useLoadNearestValues({
     columns,
     timeoffsets,
     strategy: loadNearest,
@@ -187,6 +192,12 @@ function CWMSInputTable({
     }
   };
 
+  const formatValueTimestamp = (tsMs) => {
+    if (!tsMs) return null;
+    const date = new Date(tsMs);
+    return date.toLocaleString("sv-SE").replace("T", " ");
+  };
+
   const formatTimestamp = (offset) => {
     if (getTimestampForInput) {
       // Use the form's timestamp function which includes snapping
@@ -242,6 +253,10 @@ function CWMSInputTable({
                 {timeoffsets.map((offset, offsetIndex) => {
                   const key = `${column.tsid}_${offset}`;
                   const cellLoading = isLoadingNearest && !matrixData[key];
+                  const valueTs =
+                    showValueTimestamp && !userEdited.current.has(key)
+                      ? formatValueTimestamp(loadedTimestamps?.[key])
+                      : null;
                   return (
                     <td key={offsetIndex} className="p-2">
                       <Input
@@ -258,6 +273,7 @@ function CWMSInputTable({
                         placeholder={cellLoading ? "Loading..." : "Enter value"}
                         className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
                         required={columnRequired}
+                        title={valueTs ? `Value from: ${valueTs}` : undefined}
                       />
                     </td>
                   );
@@ -311,6 +327,10 @@ function CWMSInputTable({
                 const columnReadonly = column.readonly ?? readonly;
                 const columnRequired = column.required ?? required;
                 const cellLoading = isLoadingNearest && !matrixData[key];
+                const valueTs =
+                  showValueTimestamp && !userEdited.current.has(key)
+                    ? formatValueTimestamp(loadedTimestamps?.[key])
+                    : null;
 
                 return (
                   <td key={colIndex} className="p-2">
@@ -328,6 +348,7 @@ function CWMSInputTable({
                       placeholder={cellLoading ? "Loading..." : "Enter value"}
                       className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
                       required={columnRequired}
+                      title={valueTs ? `Value from: ${valueTs}` : undefined}
                     />
                   </td>
                 );

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -13,7 +13,7 @@ function CWMSInputTable({
   precision = 2,
   order = 1,
   AllowMissingData = true,
-  loadNearest = "prev",
+  loadNearest,
   readonly = false,
   units = "EN",
   onChange,
@@ -52,12 +52,12 @@ function CWMSInputTable({
   } = useLoadNearestValues({
     columns,
     timeoffsets,
-    strategy: loadNearest,
+    strategy: loadNearest || "prev",
     getTimestampForInput,
     office,
     cdaUrl,
     defaultUnits: units,
-    enabled: !!office && columns.length > 0 && timeoffsets.length > 0,
+    enabled: !!office && !!loadNearest && columns.length > 0 && timeoffsets.length > 0,
   });
 
   useEffect(() => {

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -142,7 +142,6 @@ function CWMSInputTable({
         units: columnUnits,
         precision: columnPrecision,
         required: columnRequired,
-        readonly: columnReadonly,
         defaultValues: columnDefaultValues = {},
       } = column;
 
@@ -162,7 +161,7 @@ function CWMSInputTable({
           order: order,
           AllowMissingData: AllowMissingData,
           loadNearest: loadNearest,
-          readonly: columnReadonly ?? readonly,
+          readonly: resolveCellSetting(column, row, "readonly", readonly),
           units: columnUnits ?? units,
           timeOffset: offset,
           required: columnRequired ?? required,
@@ -296,7 +295,6 @@ function CWMSInputTable({
         </thead>
         <tbody>
           {columns.map((column, colIndex) => {
-            const columnReadonly = column.readonly ?? readonly;
             const columnRequired = column.required ?? required;
 
             return (
@@ -312,6 +310,12 @@ function CWMSInputTable({
                 {rows.map((row, offsetIndex) => {
                   const key = cellKeyFor(column, row);
                   const columnDisabled = cellIsDisabled(column, row);
+                  const columnReadonly = resolveCellSetting(
+                    column,
+                    row,
+                    "readonly",
+                    readonly,
+                  );
                   const cellLoading = isLoadingNearest && !matrixData[key];
                   const valueTs =
                     showValueTimestamp && !userEdited.current.has(key)
@@ -382,7 +386,12 @@ function CWMSInputTable({
               )}
               {columns.map((column, colIndex) => {
                 const key = cellKeyFor(column, row);
-                const columnReadonly = column.readonly ?? readonly;
+                const columnReadonly = resolveCellSetting(
+                  column,
+                  row,
+                  "readonly",
+                  readonly,
+                );
                 const columnRequired = column.required ?? required;
                 const columnDisabled = cellIsDisabled(column, row);
                 const cellLoading = isLoadingNearest && !matrixData[key];

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
 import { useNearestValues } from "../hooks/useNearestValueStore";
-import { cellKeyFor } from "../hooks/useLoadNearestValues";
+import {
+  cellKeyFor,
+  normalizeRows,
+  resolveCellSetting,
+} from "../hooks/useLoadNearestValues";
 
 function CWMSInputTable({
   className,
@@ -39,14 +43,24 @@ function CWMSInputTable({
     return data;
   };
 
-  // Whether a column loads values is decided per column, falling back to the
-  // table. Only the opted-in columns are handed to the store, so a column left
-  // out stays empty for entry.
-  const columnLoadsNearest = (column) => !!(column.loadNearest ?? loadNearest);
+  // timeoffsets accepts plain numbers or row objects that carry their own
+  // overrides, the same ones a column can set.
+  const rows = useMemo(() => normalizeRows(timeoffsets), [timeoffsets]);
+
+  const cellLoadsNearest = (column, row) =>
+    !!resolveCellSetting(column, row, "loadNearest", loadNearest);
+  const cellIsDisabled = (column, row) =>
+    !!(
+      resolveCellSetting(column, row, "disabled", undefined) ??
+      resolveCellSetting(column, row, "disable", disable)
+    );
+
+  // Only the opted-in columns are handed to the store, so a column left out
+  // stays empty for entry even when a sibling pulls the same series.
   const loadingColumns = useMemo(
-    () => columns.filter(columnLoadsNearest),
+    () => columns.filter((column) => rows.some((row) => cellLoadsNearest(column, row))),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns, loadNearest],
+    [columns, rows, loadNearest],
   );
 
   const [matrixData, setMatrixData] = useState(getInitialMatrixData);
@@ -78,19 +92,20 @@ function CWMSInputTable({
       const next = { ...prev };
       let changed = false;
 
-      // Walk the opted-in columns rather than the loaded map, so a column that
-      // did not ask to load is left alone even when a sibling column pulls the
-      // same time series.
+      // Walk the opted-in cells rather than the loaded map, so a cell that did
+      // not ask to load is left alone even when another cell pulls the same
+      // time series.
       loadingColumns.forEach((column) => {
         const columnDefaults = column.defaultValues ?? {};
         const p = column.precision ?? precision;
 
-        timeoffsets.forEach((offset) => {
-          const key = cellKeyFor(column, offset);
+        rows.forEach((row) => {
+          if (!cellLoadsNearest(column, row)) return;
+          const key = cellKeyFor(column, row);
           const value = loadedValues[key];
           if (value == null) return;
           // A caller-supplied default takes precedence over a fetched value.
-          if (columnDefaults[offset] !== undefined) return;
+          if (columnDefaults[row.offset] !== undefined) return;
           if (userEdited.current.has(key)) return;
 
           const rounded = parseFloat(value.toFixed(p)).toString();
@@ -103,7 +118,8 @@ function CWMSInputTable({
 
       return changed ? next : prev;
     });
-  }, [loadedValues, isLoadingNearest, loadingColumns, timeoffsets, precision]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadedValues, isLoadingNearest, loadingColumns, rows, precision, loadNearest]);
 
   useEffect(() => {
     userEdited.current.clear();
@@ -130,12 +146,13 @@ function CWMSInputTable({
         defaultValues: columnDefaultValues = {},
       } = column;
 
-      // A disabled column is display-only: skip it so it never submits, and so
-      // a reference column cannot collide with the entry column beside it.
-      if (column.disabled ?? column.disable) return;
+      rows.forEach((row) => {
+        const offset = row.offset;
+        // A disabled cell is display-only: skip it so it never submits, and so
+        // a reference column cannot collide with the entry column beside it.
+        if (cellIsDisabled(column, row)) return;
 
-      timeoffsets.forEach((offset) => {
-        const key = cellKeyFor(column, offset);
+        const key = cellKeyFor(column, row);
 
         const cellRef = {
           name: key,
@@ -191,10 +208,12 @@ function CWMSInputTable({
       cleanupFunctions.current.forEach((cleanup) => cleanup());
       cleanupFunctions.current = [];
     };
+    // cellIsDisabled is derived from columns/rows/disable, all listed here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     registerInput,
     columns,
-    timeoffsets,
+    rows,
     matrixData,
     precision,
     order,
@@ -206,8 +225,12 @@ function CWMSInputTable({
     disable,
   ]);
 
-  const handleInputChange = (column, offset, value) => {
-    const key = cellKeyFor(column, offset);
+  const handleInputChange = (column, row, value) => {
+    // Belt and braces: a disabled cell is display-only, so never record an edit
+    // for one even if a change event reaches us.
+    if (cellIsDisabled(column, row)) return;
+
+    const key = cellKeyFor(column, row);
     userEdited.current.add(key);
     const updatedData = {
       ...matrixData,
@@ -255,17 +278,17 @@ function CWMSInputTable({
         <thead>
           <tr>
             <th className="p-2 text-left border-b-2 border-gray-300">Parameter</th>
-            {timeoffsets.map((offset, index) => (
+            {rows.map((row, index) => (
               <th key={index} className="p-2 text-left border-b-2 border-gray-300">
                 {showTimestamps ? (
                   <Input
                     type="text"
-                    value={formatTimestamp(offset)}
+                    value={formatTimestamp(row.offset)}
                     readOnly
                     className="w-full bg-gray-50 border border-gray-300 p-1"
                   />
                 ) : (
-                  `Offset ${offset}s`
+                  row.label || `Offset ${row.offset}s`
                 )}
               </th>
             ))}
@@ -275,7 +298,6 @@ function CWMSInputTable({
           {columns.map((column, colIndex) => {
             const columnReadonly = column.readonly ?? readonly;
             const columnRequired = column.required ?? required;
-            const columnDisabled = column.disabled ?? column.disable ?? disable;
 
             return (
               <tr key={colIndex}>
@@ -287,8 +309,9 @@ function CWMSInputTable({
                     </span>
                   )}
                 </td>
-                {timeoffsets.map((offset, offsetIndex) => {
-                  const key = cellKeyFor(column, offset);
+                {rows.map((row, offsetIndex) => {
+                  const key = cellKeyFor(column, row);
+                  const columnDisabled = cellIsDisabled(column, row);
                   const cellLoading = isLoadingNearest && !matrixData[key];
                   const valueTs =
                     showValueTimestamp && !userEdited.current.has(key)
@@ -301,9 +324,7 @@ function CWMSInputTable({
                         type="number"
                         step={column.step}
                         value={matrixData[key] || ""}
-                        onChange={(e) =>
-                          handleInputChange(column, offset, e.target.value)
-                        }
+                        onChange={(e) => handleInputChange(column, row, e.target.value)}
                         disabled={columnDisabled}
                         readOnly={columnReadonly}
                         invalid={invalidCells[key] || invalid ? "true" : undefined}
@@ -344,8 +365,8 @@ function CWMSInputTable({
         </tr>
       </thead>
       <tbody>
-        {timeoffsets.map((offset, rowIndex) => {
-          const formattedTime = formatTimestamp(offset);
+        {rows.map((row, rowIndex) => {
+          const formattedTime = formatTimestamp(row.offset);
 
           return (
             <tr key={rowIndex}>
@@ -360,10 +381,10 @@ function CWMSInputTable({
                 </td>
               )}
               {columns.map((column, colIndex) => {
-                const key = cellKeyFor(column, offset);
+                const key = cellKeyFor(column, row);
                 const columnReadonly = column.readonly ?? readonly;
                 const columnRequired = column.required ?? required;
-                const columnDisabled = column.disabled ?? column.disable ?? disable;
+                const columnDisabled = cellIsDisabled(column, row);
                 const cellLoading = isLoadingNearest && !matrixData[key];
                 const valueTs =
                   showValueTimestamp && !userEdited.current.has(key)
@@ -377,9 +398,7 @@ function CWMSInputTable({
                       type="number"
                       step={column.step}
                       value={matrixData[key] || ""}
-                      onChange={(e) =>
-                        handleInputChange(column, offset, e.target.value)
-                      }
+                      onChange={(e) => handleInputChange(column, row, e.target.value)}
                       disabled={columnDisabled}
                       readOnly={columnReadonly}
                       invalid={invalidCells[key] || invalid ? "true" : undefined}

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -225,9 +225,10 @@ function CWMSInputTable({
   ]);
 
   const handleInputChange = (column, row, value) => {
-    // Belt and braces: a disabled cell is display-only, so never record an edit
-    // for one even if a change event reaches us.
+    // Belt and braces: a disabled or read-only cell is not user editable, so
+    // never record an edit for one even if a change event reaches us.
     if (cellIsDisabled(column, row)) return;
+    if (resolveCellSetting(column, row, "readonly", readonly)) return;
 
     const key = cellKeyFor(column, row);
     userEdited.current.add(key);

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -277,6 +277,7 @@ function CWMSInputTable({
         value: matrixData[key],
         loadedRaw: loadedValues?.[key],
         precision: column.precision ?? precision,
+        defaultValue: column.defaultValues?.[row.offset],
       }),
       key,
       tsid: column.tsid,

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext, useRef } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
-import useLoadNearestValues from "../hooks/useLoadNearestValues";
+import { useNearestValues } from "../hooks/useNearestValueStore";
 
 function CWMSInputTable({
   className,
@@ -22,7 +22,7 @@ function CWMSInputTable({
   required = false,
   transpose = false,
 }) {
-  const { registerInput, getTimestampForInput, office, cdaUrl, baseTimestamp } =
+  const { registerInput, getTimestampForInput, baseTimestamp } =
     useContext(FormContext);
 
   // Initialize matrixData from column defaultValues
@@ -49,15 +49,12 @@ function CWMSInputTable({
     values: loadedValues,
     timestamps: loadedTimestamps,
     isPending: isLoadingNearest,
-  } = useLoadNearestValues({
+  } = useNearestValues({
     columns,
     timeoffsets,
     strategy: loadNearest || "prev",
-    getTimestampForInput,
-    office,
-    cdaUrl,
     defaultUnits: units,
-    enabled: !!office && !!loadNearest && columns.length > 0 && timeoffsets.length > 0,
+    enabled: !!loadNearest && columns.length > 0 && timeoffsets.length > 0,
   });
 
   useEffect(() => {

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState, useContext, useRef } from "react";
+import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { Input } from "@usace/groundwork";
 import { FormContext } from "../CWMSForm";
 import { useNearestValues } from "../hooks/useNearestValueStore";
+import { cellKeyFor } from "../hooks/useLoadNearestValues";
 
 function CWMSInputTable({
   className,
@@ -31,13 +32,22 @@ function CWMSInputTable({
     columns.forEach((column) => {
       if (column.defaultValues) {
         Object.entries(column.defaultValues).forEach(([offset, value]) => {
-          const key = `${column.tsid}_${offset}`;
-          data[key] = value;
+          data[cellKeyFor(column, offset)] = value;
         });
       }
     });
     return data;
   };
+
+  // Whether a column loads values is decided per column, falling back to the
+  // table. Only the opted-in columns are handed to the store, so a column left
+  // out stays empty for entry.
+  const columnLoadsNearest = (column) => !!(column.loadNearest ?? loadNearest);
+  const loadingColumns = useMemo(
+    () => columns.filter(columnLoadsNearest),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columns, loadNearest],
+  );
 
   const [matrixData, setMatrixData] = useState(getInitialMatrixData);
   const [invalidCells, setInvalidCells] = useState({});
@@ -50,11 +60,11 @@ function CWMSInputTable({
     timestamps: loadedTimestamps,
     isPending: isLoadingNearest,
   } = useNearestValues({
-    columns,
+    columns: loadingColumns,
     timeoffsets,
     strategy: loadNearest || "prev",
     defaultUnits: units,
-    enabled: !!loadNearest && columns.length > 0 && timeoffsets.length > 0,
+    enabled: loadingColumns.length > 0 && timeoffsets.length > 0,
   });
 
   useEffect(() => {
@@ -63,35 +73,37 @@ function CWMSInputTable({
 
   useEffect(() => {
     if (isLoadingNearest || !loadedValues) return;
-    const precisionByTsid = {};
-    columns.forEach((col) => {
-      precisionByTsid[col.tsid] = col.precision ?? precision;
-    });
+
     setMatrixData((prev) => {
       const next = { ...prev };
       let changed = false;
-      const defaultKeys = new Set();
-      columns.forEach((col) => {
-        if (col.defaultValues) {
-          Object.keys(col.defaultValues).forEach((offset) => {
-            defaultKeys.add(`${col.tsid}_${offset}`);
-          });
-        }
-      });
-      Object.entries(loadedValues).forEach(([key, value]) => {
-        if (!userEdited.current.has(key) && !defaultKeys.has(key) && value != null) {
-          const tsid = key.substring(0, key.lastIndexOf("_"));
-          const p = precisionByTsid[tsid] ?? precision;
+
+      // Walk the opted-in columns rather than the loaded map, so a column that
+      // did not ask to load is left alone even when a sibling column pulls the
+      // same time series.
+      loadingColumns.forEach((column) => {
+        const columnDefaults = column.defaultValues ?? {};
+        const p = column.precision ?? precision;
+
+        timeoffsets.forEach((offset) => {
+          const key = cellKeyFor(column, offset);
+          const value = loadedValues[key];
+          if (value == null) return;
+          // A caller-supplied default takes precedence over a fetched value.
+          if (columnDefaults[offset] !== undefined) return;
+          if (userEdited.current.has(key)) return;
+
           const rounded = parseFloat(value.toFixed(p)).toString();
           if (next[key] !== rounded) {
             next[key] = rounded;
             changed = true;
           }
-        }
+        });
       });
+
       return changed ? next : prev;
     });
-  }, [loadedValues, isLoadingNearest, columns, precision]);
+  }, [loadedValues, isLoadingNearest, loadingColumns, timeoffsets, precision]);
 
   useEffect(() => {
     userEdited.current.clear();
@@ -118,8 +130,12 @@ function CWMSInputTable({
         defaultValues: columnDefaultValues = {},
       } = column;
 
+      // A disabled column is display-only: skip it so it never submits, and so
+      // a reference column cannot collide with the entry column beside it.
+      if (column.disabled ?? column.disable) return;
+
       timeoffsets.forEach((offset) => {
-        const key = `${tsid}_${offset}`;
+        const key = cellKeyFor(column, offset);
 
         const cellRef = {
           name: key,
@@ -190,8 +206,8 @@ function CWMSInputTable({
     disable,
   ]);
 
-  const handleInputChange = (tsid, offset, value) => {
-    const key = `${tsid}_${offset}`;
+  const handleInputChange = (column, offset, value) => {
+    const key = cellKeyFor(column, offset);
     userEdited.current.add(key);
     const updatedData = {
       ...matrixData,
@@ -259,6 +275,7 @@ function CWMSInputTable({
           {columns.map((column, colIndex) => {
             const columnReadonly = column.readonly ?? readonly;
             const columnRequired = column.required ?? required;
+            const columnDisabled = column.disabled ?? column.disable ?? disable;
 
             return (
               <tr key={colIndex}>
@@ -271,7 +288,7 @@ function CWMSInputTable({
                   )}
                 </td>
                 {timeoffsets.map((offset, offsetIndex) => {
-                  const key = `${column.tsid}_${offset}`;
+                  const key = cellKeyFor(column, offset);
                   const cellLoading = isLoadingNearest && !matrixData[key];
                   const valueTs =
                     showValueTimestamp && !userEdited.current.has(key)
@@ -285,9 +302,9 @@ function CWMSInputTable({
                         step={column.step}
                         value={matrixData[key] || ""}
                         onChange={(e) =>
-                          handleInputChange(column.tsid, offset, e.target.value)
+                          handleInputChange(column, offset, e.target.value)
                         }
-                        disabled={disable}
+                        disabled={columnDisabled}
                         readOnly={columnReadonly}
                         invalid={invalidCells[key] || invalid ? "true" : undefined}
                         placeholder={cellLoading ? "Loading..." : "Enter value"}
@@ -343,9 +360,10 @@ function CWMSInputTable({
                 </td>
               )}
               {columns.map((column, colIndex) => {
-                const key = `${column.tsid}_${offset}`;
+                const key = cellKeyFor(column, offset);
                 const columnReadonly = column.readonly ?? readonly;
                 const columnRequired = column.required ?? required;
+                const columnDisabled = column.disabled ?? column.disable ?? disable;
                 const cellLoading = isLoadingNearest && !matrixData[key];
                 const valueTs =
                   showValueTimestamp && !userEdited.current.has(key)
@@ -360,9 +378,9 @@ function CWMSInputTable({
                       step={column.step}
                       value={matrixData[key] || ""}
                       onChange={(e) =>
-                        handleInputChange(column.tsid, offset, e.target.value)
+                        handleInputChange(column, offset, e.target.value)
                       }
-                      disabled={disable}
+                      disabled={columnDisabled}
                       readOnly={columnReadonly}
                       invalid={invalidCells[key] || invalid ? "true" : undefined}
                       placeholder={cellLoading ? "Loading..." : "Enter value"}

--- a/lib/components/data/forms/inputs/CWMSInputTable.jsx
+++ b/lib/components/data/forms/inputs/CWMSInputTable.jsx
@@ -4,9 +4,19 @@ import { FormContext } from "../CWMSForm";
 import { useNearestValues } from "../hooks/useNearestValueStore";
 import {
   cellKeyFor,
+  getCellStatus,
   normalizeRows,
   resolveCellSetting,
 } from "../hooks/useLoadNearestValues";
+
+// Distinguishes a value the operator entered from one that was loaded for them.
+// Applied as inline style rather than a class: the Groundwork Input puts
+// className on its wrapping control element while the inner input carries its
+// own text colour, so a class here would never win. Weight carries the signal
+// as well as dimming, so it survives greyscale and colour-vision deficiency,
+// and neither cue assumes a light or dark theme.
+const PREFILLED_STYLE = { opacity: 0.7 };
+const CHANGED_STYLE = { fontWeight: 600 };
 
 function CWMSInputTable({
   className,
@@ -26,6 +36,8 @@ function CWMSInputTable({
   showValueTimestamp = false,
   required = false,
   transpose = false,
+  highlightChanged = true,
+  cellClassName,
 }) {
   const { registerInput, getTimestampForInput, baseTimestamp } =
     useContext(FormContext);
@@ -251,6 +263,40 @@ function CWMSInputTable({
     }
   };
 
+  /**
+   * Status of one cell relative to the value loaded for it, plus how to present
+   * it. `cellClassName` receives the same status so callers can react to
+   * changed / unchanged however they like; what it returns is applied to the
+   * cell, which is ours to style, rather than to the input the Groundwork
+   * component owns.
+   */
+  const cellPresentation = (column, row) => {
+    const key = cellKeyFor(column, row);
+    const status = {
+      ...getCellStatus({
+        value: matrixData[key],
+        loadedRaw: loadedValues?.[key],
+        precision: column.precision ?? precision,
+      }),
+      key,
+      tsid: column.tsid,
+      offset: row.offset,
+      column,
+      row,
+    };
+
+    let inputStyle;
+    if (highlightChanged && status.loaded) {
+      inputStyle = status.changed ? CHANGED_STYLE : PREFILLED_STYLE;
+    }
+
+    return {
+      status,
+      inputStyle,
+      cellClass: cellClassName ? cellClassName(status) || "" : "",
+    };
+  };
+
   const formatValueTimestamp = (tsMs) => {
     if (!tsMs) return null;
     const date = new Date(tsMs);
@@ -310,6 +356,7 @@ function CWMSInputTable({
                 </td>
                 {rows.map((row, offsetIndex) => {
                   const key = cellKeyFor(column, row);
+                  const { inputStyle, cellClass } = cellPresentation(column, row);
                   const columnDisabled = cellIsDisabled(column, row);
                   const columnReadonly = resolveCellSetting(
                     column,
@@ -323,7 +370,7 @@ function CWMSInputTable({
                       ? formatValueTimestamp(loadedTimestamps?.[key])
                       : null;
                   return (
-                    <td key={offsetIndex} className="p-2">
+                    <td key={offsetIndex} className={`p-2 ${cellClass}`.trim()}>
                       <Input
                         name={key}
                         type="number"
@@ -335,6 +382,7 @@ function CWMSInputTable({
                         invalid={invalidCells[key] || invalid ? "true" : undefined}
                         placeholder={cellLoading ? "Loading..." : "Enter value"}
                         className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
+                        style={inputStyle}
                         required={columnRequired}
                         title={valueTs ? `Value from: ${valueTs}` : undefined}
                       />
@@ -387,6 +435,7 @@ function CWMSInputTable({
               )}
               {columns.map((column, colIndex) => {
                 const key = cellKeyFor(column, row);
+                const { inputStyle, cellClass } = cellPresentation(column, row);
                 const columnReadonly = resolveCellSetting(
                   column,
                   row,
@@ -402,7 +451,7 @@ function CWMSInputTable({
                     : null;
 
                 return (
-                  <td key={colIndex} className="p-2">
+                  <td key={colIndex} className={`p-2 ${cellClass}`.trim()}>
                     <Input
                       name={key}
                       type="number"
@@ -414,6 +463,7 @@ function CWMSInputTable({
                       invalid={invalidCells[key] || invalid ? "true" : undefined}
                       placeholder={cellLoading ? "Loading..." : "Enter value"}
                       className={`w-full ${invalidCells[key] ? "border-red-500" : ""} ${cellLoading ? "animate-pulse opacity-60" : ""}`}
+                      style={inputStyle}
                       required={columnRequired}
                       title={valueTs ? `Value from: ${valueTs}` : undefined}
                     />

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -317,6 +317,7 @@ function CWMSSpreadsheet({
   };
 
   const handleCellChange = (rowIndex, colIndex, value) => {
+    // Don't allow editing time column
     if (shouldShowTimestamps && colIndex === 0) {
       return;
     }

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -25,6 +25,7 @@ function CWMSSpreadsheet({
   timeoffsets = [],
   required = false,
   cellOverrides = {},
+  showValueTimestamp = false,
   transpose = false,
 }) {
   const { registerInput, baseTimestamp, getTimestampForInput, office, cdaUrl } =
@@ -66,7 +67,11 @@ function CWMSSpreadsheet({
 
   const tsidColumns = useMemo(() => columns.filter((c) => c.tsid), [columns]);
 
-  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+  const {
+    values: loadedValues,
+    timestamps: loadedTimestamps,
+    isPending: isLoadingNearest,
+  } = useLoadNearestValues({
     columns: tsidColumns,
     timeoffsets,
     strategy: loadNearest,
@@ -76,6 +81,18 @@ function CWMSSpreadsheet({
     defaultUnits: units,
     enabled: !!office && tsidColumns.length > 0 && timeoffsets.length > 0,
   });
+
+  const getValueTimestampTitle = (dRow, dCol) => {
+    if (!showValueTimestamp || !loadedTimestamps) return undefined;
+    const cellKey = `${dRow}_${dCol}`;
+    if (userEdited.current.has(cellKey)) return undefined;
+    const colIdx = shouldShowTimestamps ? dCol - 1 : dCol;
+    const col = columns[colIdx];
+    if (!col?.tsid || timeoffsets[dRow] === undefined) return undefined;
+    const ts = loadedTimestamps[`${col.tsid}_${timeoffsets[dRow]}`];
+    if (!ts) return undefined;
+    return `Value from: ${new Date(ts).toLocaleString("sv-SE").replace("T", " ")}`;
+  };
 
   useEffect(() => {
     if (isLoadingNearest || !loadedValues) return;
@@ -898,6 +915,7 @@ function CWMSSpreadsheet({
                               readOnly={
                                 cellReadonly || (shouldShowTimestamps && dCol === 0)
                               }
+                              title={getValueTimestampTitle(dRow, dCol)}
                               style={{
                                 ...inputStyle,
                                 cursor: "cell",
@@ -1011,6 +1029,7 @@ function CWMSSpreadsheet({
                             readOnly={
                               cellReadonly || (shouldShowTimestamps && colIndex === 0)
                             }
+                            title={getValueTimestampTitle(rowIndex, colIndex)}
                             style={{
                               ...inputStyle,
                               cursor: "cell",

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { FormContext } from "../CWMSForm";
-import useLoadNearestValues from "../hooks/useLoadNearestValues";
+import { useNearestValues } from "../hooks/useNearestValueStore";
 
 function CWMSSpreadsheet({
   style,
@@ -28,7 +28,7 @@ function CWMSSpreadsheet({
   showValueTimestamp = false,
   transpose = false,
 }) {
-  const { registerInput, baseTimestamp, getTimestampForInput, office, cdaUrl } =
+  const { registerInput, baseTimestamp, getTimestampForInput } =
     useContext(FormContext);
   // Determine if we should show timestamps and prepare columns
   const shouldShowTimestamps = showTimestamps || timeoffsets.length > 0;
@@ -72,16 +72,12 @@ function CWMSSpreadsheet({
     values: loadedValues,
     timestamps: loadedTimestamps,
     isPending: isLoadingNearest,
-  } = useLoadNearestValues({
+  } = useNearestValues({
     columns: tsidColumns,
     timeoffsets,
     strategy: loadNearest || "prev",
-    getTimestampForInput,
-    office,
-    cdaUrl,
     defaultUnits: units,
-    enabled:
-      !!office && !!loadNearest && tsidColumns.length > 0 && timeoffsets.length > 0,
+    enabled: !!loadNearest && tsidColumns.length > 0 && timeoffsets.length > 0,
   });
 
   const getValueTimestampTitle = (dRow, dCol) => {

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -1,6 +1,16 @@
 import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { FormContext } from "../CWMSForm";
 import { useNearestValues } from "../hooks/useNearestValueStore";
+import {
+  cellKeyFor,
+  getCellStatus,
+  normalizeRows,
+} from "../hooks/useLoadNearestValues";
+
+// Matches CWMSInputTable: dim a value that was loaded for the operator, embolden
+// one they changed. Inline style because the Groundwork input owns its classes.
+const PREFILLED_STYLE = { opacity: 0.7 };
+const CHANGED_STYLE = { fontWeight: 600 };
 
 function CWMSSpreadsheet({
   style,
@@ -27,9 +37,15 @@ function CWMSSpreadsheet({
   cellOverrides = {},
   showValueTimestamp = false,
   transpose = false,
+  highlightChanged = true,
+  cellClassName,
 }) {
   const { registerInput, baseTimestamp, getTimestampForInput } =
     useContext(FormContext);
+  // timeoffsets accepts plain numbers or row objects carrying their own
+  // overrides. Named rowSpecs because `rows` is the row-count prop.
+  const rowSpecs = useMemo(() => normalizeRows(timeoffsets), [timeoffsets]);
+
   // Determine if we should show timestamps and prepare columns
   const shouldShowTimestamps = showTimestamps || timeoffsets.length > 0;
   const effectiveColumns = useMemo(
@@ -86,8 +102,8 @@ function CWMSSpreadsheet({
     if (userEdited.current.has(cellKey)) return undefined;
     const colIdx = shouldShowTimestamps ? dCol - 1 : dCol;
     const col = columns[colIdx];
-    if (!col?.tsid || timeoffsets[dRow] === undefined) return undefined;
-    const ts = loadedTimestamps[`${col.tsid}_${timeoffsets[dRow]}`];
+    if (!col?.tsid || rowSpecs[dRow] === undefined) return undefined;
+    const ts = loadedTimestamps[cellKeyFor(col, rowSpecs[dRow])];
     if (!ts) return undefined;
     return `Value from: ${new Date(ts).toLocaleString("sv-SE").replace("T", " ")}`;
   };
@@ -104,23 +120,25 @@ function CWMSSpreadsheet({
       columns.forEach((column, colIdx) => {
         if (!column.tsid) return;
         const dataColIndex = shouldShowTimestamps ? colIdx + 1 : colIdx;
-        timeoffsets.forEach((offsetVal, rowIdx) => {
-          const nearestKey = `${column.tsid}_${offsetVal}`;
+        const p = column.precision ?? precision;
+        rowSpecs.forEach((rowSpec, rowIdx) => {
+          const nearestKey = cellKeyFor(column, rowSpec);
           const cellKey = `${rowIdx}_${dataColIndex}`;
           const val = loadedValues[nearestKey];
-          const hasDefault = shouldShowTimestamps
-            ? !!defaultData[rowIdx]?.[colIdx]
-            : !!defaultData[rowIdx]?.[dataColIndex];
+          const hasDefault = defaultData[rowIdx]?.[colIdx] !== undefined;
+          // Round the way the table does, so the same series reads the same in
+          // both components and change detection compares like with like.
+          const display = val == null ? null : parseFloat(val.toFixed(p)).toString();
           if (
             !userEdited.current.has(cellKey) &&
             !hasDefault &&
-            val != null &&
-            next[rowIdx]?.[dataColIndex] !== String(val)
+            display != null &&
+            next[rowIdx]?.[dataColIndex] !== display
           ) {
             if (!next[rowIdx]) {
               next[rowIdx] = Array(effectiveColumns.length).fill("");
             }
-            next[rowIdx][dataColIndex] = String(val);
+            next[rowIdx][dataColIndex] = display;
             changed = true;
           }
         });
@@ -131,7 +149,9 @@ function CWMSSpreadsheet({
     loadedValues,
     isLoadingNearest,
     columns,
-    timeoffsets,
+    rowSpecs,
+    precision,
+    defaultData,
     shouldShowTimestamps,
     effectiveColumns.length,
   ]);
@@ -139,6 +159,44 @@ function CWMSSpreadsheet({
   useEffect(() => {
     userEdited.current.clear();
   }, [baseTimestamp]);
+
+  /**
+   * Status of one cell relative to the value it started with, plus how to show
+   * it. Mirrors CWMSInputTable: `cellClassName` receives the status and its
+   * result lands on the cell, while the built-in treatment is an inline style
+   * because the Groundwork input owns its own classes.
+   */
+  const cellPresentation = (dRow, dCol) => {
+    const colIdx = shouldShowTimestamps ? dCol - 1 : dCol;
+    const column = columns[colIdx];
+    const rowSpec = rowSpecs[dRow];
+    if (!column?.tsid || !rowSpec) return { inputStyle: undefined, cellClass: "" };
+
+    const cellOverride = cellOverrides[`${dRow}_${dCol}`] || {};
+    const status = {
+      ...getCellStatus({
+        value: spreadsheetData[dRow]?.[dCol],
+        loadedRaw: loadedValues?.[cellKeyFor(column, rowSpec)],
+        precision: cellOverride.precision ?? column.precision ?? precision,
+        defaultValue: defaultData[dRow]?.[colIdx],
+      }),
+      key: `${dRow}_${dCol}`,
+      tsid: column.tsid,
+      offset: rowSpec.offset,
+      column,
+      row: rowSpec,
+    };
+
+    let statusStyle;
+    if (highlightChanged && status.loaded) {
+      statusStyle = status.changed ? CHANGED_STYLE : PREFILLED_STYLE;
+    }
+
+    return {
+      statusStyle,
+      cellClass: cellClassName ? cellClassName(status) || "" : "",
+    };
+  };
 
   useEffect(() => {
     if (!registerInput) return;
@@ -169,7 +227,8 @@ function CWMSSpreadsheet({
         const cellTsid = cellOverride.tsid || column.tsid || `cell_${key}`;
 
         // Get cell-specific timeOffset (if timeoffsets array is provided for rows)
-        const cellTimeOffset = cellOverride.offset ?? timeoffsets[rowIndex] ?? offset;
+        const cellTimeOffset =
+          cellOverride.offset ?? rowSpecs[rowIndex]?.offset ?? offset;
 
         const cellRef = {
           name: key,
@@ -192,7 +251,10 @@ function CWMSSpreadsheet({
           },
           reset: () => {
             userEdited.current.delete(key);
-            const nearestKey = `${cellTsid}_${cellTimeOffset}`;
+            const nearestKey = cellKeyFor(
+              { ...column, tsid: cellTsid },
+              rowSpecs[rowIndex] ?? { offset: cellTimeOffset },
+            );
             const nearestRaw = loadedValuesRef.current[nearestKey];
 
             setSpreadsheetData((prev) => {
@@ -206,11 +268,13 @@ function CWMSSpreadsheet({
               // Mirror the populate effect: a caller-supplied default takes
               // precedence over the fetched nearest value.
               const defaultVal = defaultData[rowIndex]?.[dataColIndex];
+              const cellPrecision =
+                cellOverride.precision ?? column.precision ?? precision;
               let resetVal;
               if (defaultVal) {
                 resetVal = defaultVal;
               } else if (nearestRaw != null) {
-                resetVal = String(nearestRaw);
+                resetVal = parseFloat(nearestRaw.toFixed(cellPrecision)).toString();
               } else {
                 resetVal = "";
               }
@@ -257,7 +321,7 @@ function CWMSSpreadsheet({
     required,
     cellOverrides,
     shouldShowTimestamps,
-    timeoffsets,
+    rowSpecs,
     baseTimestamp,
     disable,
   ]);
@@ -416,8 +480,8 @@ function CWMSSpreadsheet({
         const { row: dRow, col: dCol } = visualToData(vRow, vCol);
         // For time column, calculate the actual time
         if (shouldShowTimestamps && dCol === 0) {
-          if (getTimestampForInput && timeoffsets[dRow] !== undefined) {
-            const timestamp = getTimestampForInput(timeoffsets[dRow]);
+          if (getTimestampForInput && rowSpecs[dRow] !== undefined) {
+            const timestamp = getTimestampForInput(rowSpecs[dRow].offset);
             const cellTime = new Date(timestamp);
             rowData.push(
               cellTime.toLocaleTimeString("en-US", {
@@ -879,14 +943,17 @@ function CWMSSpreadsheet({
                         const defaultPlaceholder =
                           cellOverride.placeholder ?? column.placeholder ?? "";
                         const cellLoading = isLoadingNearest && !row[dCol];
+                        const { statusStyle, cellClass } = cellPresentation(dRow, dCol);
                         const cellPlaceholder = cellLoading
                           ? "Loading..."
                           : defaultPlaceholder;
 
                         let displayValue = row[dCol];
                         if (shouldShowTimestamps && dCol === 0) {
-                          if (getTimestampForInput && timeoffsets[dRow] !== undefined) {
-                            const timestamp = getTimestampForInput(timeoffsets[dRow]);
+                          if (getTimestampForInput && rowSpecs[dRow] !== undefined) {
+                            const timestamp = getTimestampForInput(
+                              rowSpecs[dRow].offset,
+                            );
                             const cellTime = new Date(timestamp);
                             displayValue = cellTime.toLocaleTimeString("en-US", {
                               hour: "2-digit",
@@ -901,6 +968,7 @@ function CWMSSpreadsheet({
                         return (
                           <td
                             key={rowIndex}
+                            className={cellClass}
                             style={{
                               ...cellStyle,
                               backgroundColor: isSelected
@@ -936,10 +1004,11 @@ function CWMSSpreadsheet({
                               title={getValueTimestampTitle(dRow, dCol)}
                               style={{
                                 ...inputStyle,
+                                ...statusStyle,
                                 cursor: "cell",
                                 pointerEvents: "auto",
                                 color: isCellInvalid ? "red" : undefined,
-                                opacity: cellLoading ? 0.6 : undefined,
+                                opacity: cellLoading ? 0.6 : statusStyle?.opacity,
                               }}
                               placeholder={cellPlaceholder}
                               required={cellRequired}
@@ -988,17 +1057,20 @@ function CWMSSpreadsheet({
                       const defaultPlaceholder =
                         cellOverride.placeholder ?? column.placeholder ?? "";
                       const cellLoading = isLoadingNearest && !cellValue;
+                      const { statusStyle, cellClass } = cellPresentation(
+                        rowIndex,
+                        colIndex,
+                      );
                       const cellPlaceholder = cellLoading
                         ? "Loading..."
                         : defaultPlaceholder;
 
                       let displayValue = cellValue;
                       if (shouldShowTimestamps && colIndex === 0) {
-                        if (
-                          getTimestampForInput &&
-                          timeoffsets[rowIndex] !== undefined
-                        ) {
-                          const timestamp = getTimestampForInput(timeoffsets[rowIndex]);
+                        if (getTimestampForInput && rowSpecs[rowIndex] !== undefined) {
+                          const timestamp = getTimestampForInput(
+                            rowSpecs[rowIndex].offset,
+                          );
                           const cellTime = new Date(timestamp);
                           displayValue = cellTime.toLocaleTimeString("en-US", {
                             hour: "2-digit",
@@ -1013,6 +1085,7 @@ function CWMSSpreadsheet({
                       return (
                         <td
                           key={colIndex}
+                          className={cellClass}
                           style={{
                             ...cellStyle,
                             backgroundColor: isSelected
@@ -1050,10 +1123,11 @@ function CWMSSpreadsheet({
                             title={getValueTimestampTitle(rowIndex, colIndex)}
                             style={{
                               ...inputStyle,
+                              ...statusStyle,
                               cursor: "cell",
                               pointerEvents: "auto",
                               color: isCellInvalid ? "red" : undefined,
-                              opacity: cellLoading ? 0.6 : undefined,
+                              opacity: cellLoading ? 0.6 : statusStyle?.opacity,
                             }}
                             placeholder={cellPlaceholder}
                             required={cellRequired}

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -60,6 +60,7 @@ function CWMSSpreadsheet({
   const tableRef = useRef(null);
   const cleanupFunctions = useRef([]);
   const userEdited = useRef(new Set());
+  const loadedValuesRef = useRef({});
 
   // Unique ID prefix for this spreadsheet instance so multiple spreadsheets
   // on the same page don't collide when using document.getElementById
@@ -93,6 +94,10 @@ function CWMSSpreadsheet({
     if (!ts) return undefined;
     return `Value from: ${new Date(ts).toLocaleString("sv-SE").replace("T", " ")}`;
   };
+
+  useEffect(() => {
+    if (loadedValues) loadedValuesRef.current = loadedValues;
+  }, [loadedValues]);
 
   useEffect(() => {
     if (isLoadingNearest || !loadedValues) return;
@@ -185,6 +190,10 @@ function CWMSSpreadsheet({
             return [spreadsheetData[rowIndex]?.[colIndex] || ""];
           },
           reset: () => {
+            userEdited.current.delete(key);
+            const nearestKey = `${cellTsid}_${cellTimeOffset}`;
+            const nearestRaw = loadedValuesRef.current[nearestKey];
+
             setSpreadsheetData((prev) => {
               const updated = [...prev];
               if (!updated[rowIndex]) {
@@ -192,12 +201,16 @@ function CWMSSpreadsheet({
               } else {
                 updated[rowIndex] = [...updated[rowIndex]];
               }
-              if (shouldShowTimestamps) {
-                updated[rowIndex][colIndex] =
-                  colIndex === 0 ? "" : defaultData[rowIndex]?.[dataColIndex] || "";
+
+              let resetVal;
+              if (nearestRaw != null) {
+                resetVal = String(nearestRaw);
+              } else if (shouldShowTimestamps) {
+                resetVal = defaultData[rowIndex]?.[dataColIndex] || "";
               } else {
-                updated[rowIndex][colIndex] = defaultData[rowIndex]?.[colIndex] || "";
+                resetVal = defaultData[rowIndex]?.[colIndex] || "";
               }
+              updated[rowIndex][colIndex] = resetVal;
               return updated;
             });
             setInvalidCells((prev) => ({

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -12,7 +12,7 @@ function CWMSSpreadsheet({
   offset = 0,
   order = 1,
   AllowMissingData = true,
-  loadNearest = "prev",
+  loadNearest,
   readonly = false,
   units = "EN",
   onChange,
@@ -75,12 +75,13 @@ function CWMSSpreadsheet({
   } = useLoadNearestValues({
     columns: tsidColumns,
     timeoffsets,
-    strategy: loadNearest,
+    strategy: loadNearest || "prev",
     getTimestampForInput,
     office,
     cdaUrl,
     defaultUnits: units,
-    enabled: !!office && tsidColumns.length > 0 && timeoffsets.length > 0,
+    enabled:
+      !!office && !!loadNearest && tsidColumns.length > 0 && timeoffsets.length > 0,
   });
 
   const getValueTimestampTitle = (dRow, dCol) => {

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext, useRef, useMemo } from "react";
 import { FormContext } from "../CWMSForm";
+import useLoadNearestValues from "../hooks/useLoadNearestValues";
 
 function CWMSSpreadsheet({
   style,
@@ -26,7 +27,7 @@ function CWMSSpreadsheet({
   cellOverrides = {},
   transpose = false,
 }) {
-  const { registerInput, baseTimestamp, getTimestampForInput } =
+  const { registerInput, baseTimestamp, getTimestampForInput, office, cdaUrl } =
     useContext(FormContext);
   // Determine if we should show timestamps and prepare columns
   const shouldShowTimestamps = showTimestamps || timeoffsets.length > 0;
@@ -57,10 +58,64 @@ function CWMSSpreadsheet({
   const [dragEnd, setDragEnd] = useState(null);
   const tableRef = useRef(null);
   const cleanupFunctions = useRef([]);
+  const userEdited = useRef(new Set());
 
   // Unique ID prefix for this spreadsheet instance so multiple spreadsheets
   // on the same page don't collide when using document.getElementById
   const instanceId = useMemo(() => `ss-${Math.random().toString(36).slice(2, 8)}`, []);
+
+  const tsidColumns = useMemo(() => columns.filter((c) => c.tsid), [columns]);
+
+  const { values: loadedValues, isPending: isLoadingNearest } = useLoadNearestValues({
+    columns: tsidColumns,
+    timeoffsets,
+    strategy: loadNearest,
+    getTimestampForInput,
+    office,
+    cdaUrl,
+    defaultUnits: units,
+    enabled: !!office && tsidColumns.length > 0 && timeoffsets.length > 0,
+  });
+
+  useEffect(() => {
+    if (isLoadingNearest || !loadedValues) return;
+    setSpreadsheetData((prev) => {
+      const next = prev.map((row) => [...row]);
+      let changed = false;
+      columns.forEach((column, colIdx) => {
+        if (!column.tsid) return;
+        const dataColIndex = shouldShowTimestamps ? colIdx + 1 : colIdx;
+        timeoffsets.forEach((offsetVal, rowIdx) => {
+          const nearestKey = `${column.tsid}_${offsetVal}`;
+          const cellKey = `${rowIdx}_${dataColIndex}`;
+          const val = loadedValues[nearestKey];
+          if (
+            !userEdited.current.has(cellKey) &&
+            val != null &&
+            next[rowIdx]?.[dataColIndex] !== String(val)
+          ) {
+            if (!next[rowIdx]) {
+              next[rowIdx] = Array(effectiveColumns.length).fill("");
+            }
+            next[rowIdx][dataColIndex] = String(val);
+            changed = true;
+          }
+        });
+      });
+      return changed ? next : prev;
+    });
+  }, [
+    loadedValues,
+    isLoadingNearest,
+    columns,
+    timeoffsets,
+    shouldShowTimestamps,
+    effectiveColumns.length,
+  ]);
+
+  useEffect(() => {
+    userEdited.current.clear();
+  }, [baseTimestamp]);
 
   useEffect(() => {
     if (!registerInput) return;
@@ -224,12 +279,12 @@ function CWMSSpreadsheet({
   };
 
   const handleCellChange = (rowIndex, colIndex, value) => {
-    // Don't allow editing time column
     if (shouldShowTimestamps && colIndex === 0) {
       return;
     }
 
     const key = `${rowIndex}_${colIndex}`;
+    userEdited.current.add(key);
     const updatedData = [...spreadsheetData];
     updatedData[rowIndex] = [...updatedData[rowIndex]];
     updatedData[rowIndex][colIndex] = value;
@@ -786,8 +841,12 @@ function CWMSSpreadsheet({
                         const cellRequired =
                           cellOverride.required ?? column.required ?? required;
                         const cellType = cellOverride.type ?? column.type ?? "text";
-                        const cellPlaceholder =
+                        const defaultPlaceholder =
                           cellOverride.placeholder ?? column.placeholder ?? "";
+                        const cellLoading = isLoadingNearest && !row[dCol];
+                        const cellPlaceholder = cellLoading
+                          ? "Loading..."
+                          : defaultPlaceholder;
 
                         let displayValue = row[dCol];
                         if (shouldShowTimestamps && dCol === 0) {
@@ -844,6 +903,7 @@ function CWMSSpreadsheet({
                                 cursor: "cell",
                                 pointerEvents: "auto",
                                 color: isCellInvalid ? "red" : undefined,
+                                opacity: cellLoading ? 0.6 : undefined,
                               }}
                               placeholder={cellPlaceholder}
                               required={cellRequired}
@@ -889,8 +949,12 @@ function CWMSSpreadsheet({
                       const cellRequired =
                         cellOverride.required ?? column.required ?? required;
                       const cellType = cellOverride.type ?? column.type ?? "text";
-                      const cellPlaceholder =
+                      const defaultPlaceholder =
                         cellOverride.placeholder ?? column.placeholder ?? "";
+                      const cellLoading = isLoadingNearest && !cellValue;
+                      const cellPlaceholder = cellLoading
+                        ? "Loading..."
+                        : defaultPlaceholder;
 
                       let displayValue = cellValue;
                       if (shouldShowTimestamps && colIndex === 0) {
@@ -952,6 +1016,7 @@ function CWMSSpreadsheet({
                               cursor: "cell",
                               pointerEvents: "auto",
                               color: isCellInvalid ? "red" : undefined,
+                              opacity: cellLoading ? 0.6 : undefined,
                             }}
                             placeholder={cellPlaceholder}
                             required={cellRequired}

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -207,13 +207,16 @@ function CWMSSpreadsheet({
                 updated[rowIndex] = [...updated[rowIndex]];
               }
 
+              // Mirror the populate effect: a caller-supplied default takes
+              // precedence over the fetched nearest value.
+              const defaultVal = defaultData[rowIndex]?.[dataColIndex];
               let resetVal;
-              if (nearestRaw != null) {
+              if (defaultVal) {
+                resetVal = defaultVal;
+              } else if (nearestRaw != null) {
                 resetVal = String(nearestRaw);
-              } else if (shouldShowTimestamps) {
-                resetVal = defaultData[rowIndex]?.[dataColIndex] || "";
               } else {
-                resetVal = defaultData[rowIndex]?.[colIndex] || "";
+                resetVal = "";
               }
               updated[rowIndex][colIndex] = resetVal;
               return updated;

--- a/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
+++ b/lib/components/data/forms/inputs/CWMSSpreadsheet.jsx
@@ -112,8 +112,12 @@ function CWMSSpreadsheet({
           const nearestKey = `${column.tsid}_${offsetVal}`;
           const cellKey = `${rowIdx}_${dataColIndex}`;
           const val = loadedValues[nearestKey];
+          const hasDefault = shouldShowTimestamps
+            ? !!defaultData[rowIdx]?.[colIdx]
+            : !!defaultData[rowIdx]?.[dataColIndex];
           if (
             !userEdited.current.has(cellKey) &&
+            !hasDefault &&
             val != null &&
             next[rowIdx]?.[dataColIndex] !== String(val)
           ) {

--- a/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
@@ -173,9 +173,15 @@ describe("CWMSInput nearest value loading", () => {
     expect(edited.title).toBeFalsy();
   });
 
+  it("does not overwrite caller-provided defaultValue", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.5 } });
+    renderInput({ defaultValue: "0" });
+    expect(screen.getByDisplayValue("0")).toBeTruthy();
+  });
+
   it("reset restores to defaultValue and allows reload", () => {
     mockHook({ values: { [`${TSID}_0`]: 42.5 } });
-    const { registerInput } = renderInput({ defaultValue: "0" });
+    const { registerInput } = renderInput();
 
     const input = screen.getByDisplayValue("42.5");
     fireEvent.change(input, { target: { value: "99" } });

--- a/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { FormContext } from "../../CWMSForm";
+import { CWMSInput } from "../CWMSInput";
+import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+
+vi.mock("../../hooks/useLoadNearestValues");
+
+const TSID = "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV";
+
+function renderInput(props = {}, contextOverrides = {}) {
+  const registerInput = vi.fn(() => vi.fn());
+  const getTimestampForInput = vi.fn(() => "2025-01-15T12:00:00.000Z");
+
+  const context = {
+    registerInput,
+    getTimestampForInput,
+    office: "SWD",
+    cdaUrl: "https://water.usace.army.mil/cwms-data",
+    baseTimestamp: "2025-01-15T12:00",
+    ...contextOverrides,
+  };
+
+  const result = render(
+    <FormContext.Provider value={context}>
+      <CWMSInput name="flow-in" label="Flow In" tsid={TSID} timeOffset={0} {...props} />
+    </FormContext.Provider>,
+  );
+
+  return { ...result, registerInput, context };
+}
+
+function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
+  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+}
+
+describe("CWMSInput nearest value loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("populates input with loaded value", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.5 } });
+    renderInput();
+    expect(screen.getByDisplayValue("42.5")).toBeTruthy();
+  });
+
+  it("shows Loading... placeholder while pending", () => {
+    mockHook({ isPending: true });
+    renderInput();
+    expect(screen.getByPlaceholderText("Loading...")).toBeTruthy();
+  });
+
+  it("does not overwrite user-edited value", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.5 } });
+    const { rerender, registerInput } = renderInput();
+
+    const input = screen.getByDisplayValue("42.5");
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(screen.getByDisplayValue("99")).toBeTruthy();
+
+    mockHook({ values: { [`${TSID}_0`]: 55.0 } });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn(() => "2025-01-15T12:00:00.000Z"),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T12:00",
+        }}
+      >
+        <CWMSInput name="flow-in" label="Flow In" tsid={TSID} timeOffset={0} />
+      </FormContext.Provider>,
+    );
+
+    expect(screen.getByDisplayValue("99")).toBeTruthy();
+    expect(screen.queryByDisplayValue("55")).toBeNull();
+  });
+
+  it("resets userEdited flag when baseTimestamp changes", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.5 } });
+    const { rerender, registerInput } = renderInput();
+
+    fireEvent.change(screen.getByDisplayValue("42.5"), {
+      target: { value: "99" },
+    });
+
+    // Phase 1: baseTimestamp changes, hook is pending (resets userEdited ref)
+    mockHook({ isPending: true });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn(() => "2025-01-15T13:00:00.000Z"),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T13:00",
+        }}
+      >
+        <CWMSInput name="flow-in" label="Flow In" tsid={TSID} timeOffset={0} />
+      </FormContext.Provider>,
+    );
+
+    // Phase 2: new values arrive after userEdited was reset
+    mockHook({ values: { [`${TSID}_0`]: 77.0 } });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn(() => "2025-01-15T13:00:00.000Z"),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T13:00",
+        }}
+      >
+        <CWMSInput name="flow-in" label="Flow In" tsid={TSID} timeOffset={0} />
+      </FormContext.Provider>,
+    );
+
+    expect(screen.getByDisplayValue("77")).toBeTruthy();
+  });
+
+  it("shows value timestamp tooltip when showValueTimestamp is true", () => {
+    const ts = new Date("2025-01-15T10:30:00Z").getTime();
+    mockHook({
+      values: { [`${TSID}_0`]: 42.5 },
+      timestamps: { [`${TSID}_0`]: ts },
+    });
+    renderInput({ showValueTimestamp: true });
+
+    const input = screen.getByDisplayValue("42.5");
+    expect(input.title).toContain("Value from:");
+  });
+
+  it("removes tooltip after user edit", () => {
+    const ts = new Date("2025-01-15T10:30:00Z").getTime();
+    mockHook({
+      values: { [`${TSID}_0`]: 42.5 },
+      timestamps: { [`${TSID}_0`]: ts },
+    });
+    const { rerender, registerInput } = renderInput({ showValueTimestamp: true });
+
+    const input = screen.getByDisplayValue("42.5");
+    expect(input.title).toContain("Value from:");
+
+    fireEvent.change(input, { target: { value: "99" } });
+
+    mockHook({
+      values: { [`${TSID}_0`]: 42.5 },
+      timestamps: { [`${TSID}_0`]: ts },
+    });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn(() => "2025-01-15T12:00:00.000Z"),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T12:00",
+        }}
+      >
+        <CWMSInput
+          name="flow-in"
+          label="Flow In"
+          tsid={TSID}
+          timeOffset={0}
+          showValueTimestamp
+        />
+      </FormContext.Provider>,
+    );
+
+    const edited = screen.getByDisplayValue("99");
+    expect(edited.title).toBeFalsy();
+  });
+
+  it("reset restores to defaultValue and allows reload", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.5 } });
+    const { registerInput } = renderInput({ defaultValue: "0" });
+
+    const input = screen.getByDisplayValue("42.5");
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(screen.getByDisplayValue("99")).toBeTruthy();
+
+    const registration = registerInput.mock.calls.at(-1)?.[0];
+    act(() => {
+      registration.reset();
+    });
+
+    // After reset, userEdited is cleared and the loadedValues effect
+    // repopulates the input with the nearest value
+    expect(screen.getByDisplayValue("42.5")).toBeTruthy();
+  });
+
+  it("passes the loadNearest strategy to the hook", () => {
+    mockHook();
+    renderInput({ loadNearest: "next" });
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: "next" }),
+    );
+  });
+
+  it("defaults loadNearest strategy to prev", () => {
+    mockHook();
+    renderInput();
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: "prev" }),
+    );
+  });
+
+  it("does not load when tsid is missing", () => {
+    mockHook();
+    renderInput({ tsid: undefined });
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInput.nearestValue.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { FormContext } from "../../CWMSForm";
 import { CWMSInput } from "../CWMSInput";
-import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+import { useNearestValues } from "../../hooks/useNearestValueStore";
 
-vi.mock("../../hooks/useLoadNearestValues");
+vi.mock("../../hooks/useNearestValueStore");
 
 const TSID = "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV";
 
@@ -30,7 +30,7 @@ function renderInput(props = {}, contextOverrides = {}) {
 }
 
 function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
-  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+  useNearestValues.mockReturnValue({ values, timestamps, isPending });
 }
 
 describe("CWMSInput nearest value loading", () => {
@@ -201,7 +201,7 @@ describe("CWMSInput nearest value loading", () => {
     mockHook();
     renderInput({ loadNearest: "next" });
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ strategy: "next" }),
     );
   });
@@ -210,7 +210,7 @@ describe("CWMSInput nearest value loading", () => {
     mockHook();
     renderInput();
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ strategy: "prev" }),
     );
   });
@@ -219,7 +219,7 @@ describe("CWMSInput nearest value loading", () => {
     mockHook();
     renderInput({ tsid: undefined });
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: false }),
     );
   });

--- a/lib/components/data/forms/inputs/__tests__/CWMSInput.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInput.test.jsx
@@ -2,6 +2,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { FormContext } from "../../CWMSForm";
 import { CWMSInput } from "../CWMSInput";
 
+vi.mock("../../hooks/useLoadNearestValues", () => ({
+  default: () => ({ values: {}, timestamps: {}, isPending: false }),
+}));
+
 describe("CWMSInput", () => {
   it("registers with the form context and propagates value changes", () => {
     const registerInput = vi.fn(() => vi.fn());

--- a/lib/components/data/forms/inputs/__tests__/CWMSInput.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInput.test.jsx
@@ -2,8 +2,8 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { FormContext } from "../../CWMSForm";
 import { CWMSInput } from "../CWMSInput";
 
-vi.mock("../../hooks/useLoadNearestValues", () => ({
-  default: () => ({ values: {}, timestamps: {}, isPending: false }),
+vi.mock("../../hooks/useNearestValueStore", () => ({
+  useNearestValues: () => ({ values: {}, timestamps: {}, isPending: false }),
 }));
 
 describe("CWMSInput", () => {

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { FormContext } from "../../CWMSForm";
+import { CWMSInputTable } from "../CWMSInputTable";
+import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+
+vi.mock("../../hooks/useLoadNearestValues");
+
+const COLUMNS = [
+  { tsid: "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV", label: "Flow In", units: "EN" },
+  { tsid: "LWG.Elev.Inst.1Hour.0.CBT-REV", label: "Elevation", units: "EN" },
+];
+
+const TIMEOFFSETS = [0, 3600];
+
+function renderTable(props = {}, contextOverrides = {}) {
+  const registerInput = vi.fn(() => vi.fn());
+  const getTimestampForInput = vi.fn((offset) => {
+    const base = new Date("2025-01-15T12:00:00Z");
+    base.setTime(base.getTime() + offset * 1000);
+    return base.toISOString();
+  });
+
+  const context = {
+    registerInput,
+    getTimestampForInput,
+    office: "SWD",
+    cdaUrl: "https://water.usace.army.mil/cwms-data",
+    baseTimestamp: "2025-01-15T12:00",
+    ...contextOverrides,
+  };
+
+  const result = render(
+    <FormContext.Provider value={context}>
+      <CWMSInputTable columns={COLUMNS} timeoffsets={TIMEOFFSETS} {...props} />
+    </FormContext.Provider>,
+  );
+
+  return { ...result, registerInput, context };
+}
+
+function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
+  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+}
+
+describe("CWMSInputTable nearest value loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("populates cells with loaded values", () => {
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 100.5,
+        [`${COLUMNS[0].tsid}_3600`]: 105.2,
+        [`${COLUMNS[1].tsid}_0`]: 735.1,
+        [`${COLUMNS[1].tsid}_3600`]: 735.4,
+      },
+    });
+    renderTable();
+
+    expect(screen.getByDisplayValue("100.5")).toBeTruthy();
+    expect(screen.getByDisplayValue("105.2")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.1")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.4")).toBeTruthy();
+  });
+
+  it("applies precision rounding to loaded values", () => {
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 42.567,
+        [`${COLUMNS[1].tsid}_0`]: 735.123,
+      },
+    });
+    renderTable({ precision: 1 });
+
+    expect(screen.getByDisplayValue("42.6")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.1")).toBeTruthy();
+  });
+
+  it("applies per-column precision", () => {
+    const cols = [
+      { ...COLUMNS[0], precision: 0 },
+      { ...COLUMNS[1], precision: 3 },
+    ];
+    mockHook({
+      values: {
+        [`${cols[0].tsid}_0`]: 42.567,
+        [`${cols[1].tsid}_0`]: 735.1234,
+      },
+    });
+    renderTable({ columns: cols });
+
+    expect(screen.getByDisplayValue("43")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.123")).toBeTruthy();
+  });
+
+  it("shows Loading... placeholder while pending", () => {
+    mockHook({ isPending: true });
+    renderTable();
+
+    const loadingInputs = screen.getAllByPlaceholderText("Loading...");
+    expect(loadingInputs.length).toBeGreaterThan(0);
+  });
+
+  it("does not overwrite user-edited cell", () => {
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 100.5,
+        [`${COLUMNS[1].tsid}_0`]: 735.1,
+      },
+    });
+    const { rerender, registerInput } = renderTable();
+
+    const input = screen.getByDisplayValue("100.5");
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(screen.getByDisplayValue("999")).toBeTruthy();
+
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 200.0,
+        [`${COLUMNS[1].tsid}_0`]: 735.1,
+      },
+    });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn((offset) => {
+            const base = new Date("2025-01-15T12:00:00Z");
+            base.setTime(base.getTime() + offset * 1000);
+            return base.toISOString();
+          }),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T12:00",
+        }}
+      >
+        <CWMSInputTable columns={COLUMNS} timeoffsets={TIMEOFFSETS} />
+      </FormContext.Provider>,
+    );
+
+    expect(screen.getByDisplayValue("999")).toBeTruthy();
+    expect(screen.queryByDisplayValue("200")).toBeNull();
+  });
+
+  it("registers all cells with FormContext", () => {
+    mockHook();
+    const { registerInput } = renderTable();
+
+    const registrations = registerInput.mock.calls.map((c) => c[0]);
+    const tsidOffsets = registrations.map((r) => `${r.tsid}_${r.timeOffset}`);
+    expect(tsidOffsets).toContain(`${COLUMNS[0].tsid}_0`);
+    expect(tsidOffsets).toContain(`${COLUMNS[0].tsid}_3600`);
+    expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_0`);
+    expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_3600`);
+  });
+
+  it("shows value timestamp tooltip when showValueTimestamp is true", () => {
+    const ts = new Date("2025-01-15T10:30:00Z").getTime();
+    mockHook({
+      values: { [`${COLUMNS[0].tsid}_0`]: 100.5 },
+      timestamps: { [`${COLUMNS[0].tsid}_0`]: ts },
+    });
+    renderTable({ showValueTimestamp: true });
+
+    const input = screen.getByDisplayValue("100.5");
+    expect(input.title).toContain("Value from:");
+  });
+
+  it("reset restores loaded value with precision", () => {
+    mockHook({
+      values: { [`${COLUMNS[0].tsid}_0`]: 42.567 },
+    });
+    const { registerInput } = renderTable({ precision: 1 });
+
+    expect(screen.getByDisplayValue("42.6")).toBeTruthy();
+
+    const input = screen.getByDisplayValue("42.6");
+    fireEvent.change(input, { target: { value: "999" } });
+
+    const registration = registerInput.mock.calls
+      .map((c) => c[0])
+      .find((r) => r.tsid === COLUMNS[0].tsid && r.timeOffset === 0);
+
+    act(() => {
+      registration.reset();
+    });
+
+    expect(screen.getByDisplayValue("42.6")).toBeTruthy();
+  });
+
+  it("passes strategy to hook", () => {
+    mockHook();
+    renderTable({ loadNearest: "nearest" });
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: "nearest" }),
+    );
+  });
+});

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -210,6 +210,61 @@ describe("CWMSInputTable nearest value loading", () => {
       expect(input.style.fontWeight).toBe("");
     });
 
+    // A caller-supplied default takes precedence over the fetched value, so the
+    // default is what the cell started at - it must not read as an edit.
+    it("treats a hard-coded default as the baseline, not as a change", () => {
+      mockHook({ values: { [KEY]: 100.5 } });
+      renderTable({
+        columns: [{ ...COLUMNS[0], defaultValues: { 0: "50" } }],
+        timeoffsets: [0],
+      });
+
+      const input = screen.getByRole("spinbutton");
+      expect(input.value).toBe("50");
+      expect(input.style.fontWeight).toBe("");
+      expect(input.style.opacity).toBe("0.7");
+    });
+
+    it("marks a defaulted cell changed once it is edited away from the default", () => {
+      mockHook({ values: { [KEY]: 100.5 } });
+      renderTable({
+        columns: [{ ...COLUMNS[0], defaultValues: { 0: "50" } }],
+        timeoffsets: [0],
+      });
+
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "51" } });
+      expect(input.style.fontWeight).toBe("600");
+
+      // ...and back to the default is unchanged again.
+      fireEvent.change(input, { target: { value: "50" } });
+      expect(input.style.opacity).toBe("0.7");
+      expect(input.style.fontWeight).toBe("");
+    });
+
+    it("reports the default as the baseline to cellClassName", () => {
+      const seen = [];
+      mockHook({ values: { [KEY]: 100.5 } });
+      renderTable({
+        columns: [{ ...COLUMNS[0], defaultValues: { 0: "50" } }],
+        timeoffsets: [0],
+        cellClassName: (status) => {
+          seen.push(status);
+          return "";
+        },
+      });
+
+      expect(seen.at(-1)).toMatchObject({
+        value: "50",
+        defaultValue: "50",
+        baseline: "50",
+        loadedValue: "100.5",
+        loaded: true,
+        changed: false,
+        prefilled: true,
+      });
+    });
+
     it("can be turned off with highlightChanged", () => {
       renderOne({ highlightChanged: false });
       expect(screen.getByRole("spinbutton").style.opacity).toBe("");

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { FormContext } from "../../CWMSForm";
 import { CWMSInputTable } from "../CWMSInputTable";
-import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+import { useNearestValues } from "../../hooks/useNearestValueStore";
 
-vi.mock("../../hooks/useLoadNearestValues");
+vi.mock("../../hooks/useNearestValueStore");
 
 const COLUMNS = [
   { tsid: "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV", label: "Flow In", units: "EN" },
@@ -39,7 +39,7 @@ function renderTable(props = {}, contextOverrides = {}) {
 }
 
 function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
-  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+  useNearestValues.mockReturnValue({ values, timestamps, isPending });
 }
 
 describe("CWMSInputTable nearest value loading", () => {
@@ -193,7 +193,7 @@ describe("CWMSInputTable nearest value loading", () => {
     mockHook();
     renderTable({ loadNearest: "nearest" });
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ strategy: "nearest" }),
     );
   });

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -160,6 +160,94 @@ describe("CWMSInputTable nearest value loading", () => {
     expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_3600`);
   });
 
+  describe("changed vs prefilled styling", () => {
+    const KEY = `${COLUMNS[0].tsid}_0`;
+
+    function renderOne(props = {}) {
+      mockHook({ values: { [KEY]: 100.5 } });
+      return renderTable({ columns: [COLUMNS[0]], timeoffsets: [0], ...props });
+    }
+
+    // Asserted on inline style, not className: the Groundwork Input applies
+    // className to its wrapping control, so only style reaches the input.
+    it("dims a prefilled cell and does not embolden it", () => {
+      renderOne();
+      const input = screen.getByRole("spinbutton");
+      expect(input.value).toBe("100.5");
+      expect(input.style.opacity).toBe("0.7");
+      expect(input.style.fontWeight).toBe("");
+    });
+
+    it("emboldens a cell the operator changed", () => {
+      renderOne();
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "108" } });
+
+      expect(input.style.fontWeight).toBe("600");
+      expect(input.style.opacity).toBe("");
+    });
+
+    // The reason status is derived by comparison rather than tracked as a flag:
+    // typing the loaded value back is not a change.
+    it("treats a cell typed back to the loaded value as unchanged", () => {
+      renderOne();
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "108" } });
+      fireEvent.change(input, { target: { value: "100.5" } });
+
+      expect(input.style.opacity).toBe("0.7");
+      expect(input.style.fontWeight).toBe("");
+    });
+
+    it("leaves cells alone when nothing was loaded for them", () => {
+      mockHook({ values: {} });
+      renderTable({ columns: [COLUMNS[0]], timeoffsets: [0] });
+      const input = screen.getByRole("spinbutton");
+      fireEvent.change(input, { target: { value: "5" } });
+
+      // No baseline to compare against, so no changed/prefilled styling.
+      expect(input.style.opacity).toBe("");
+      expect(input.style.fontWeight).toBe("");
+    });
+
+    it("can be turned off with highlightChanged", () => {
+      renderOne({ highlightChanged: false });
+      expect(screen.getByRole("spinbutton").style.opacity).toBe("");
+    });
+
+    it("passes cell status to cellClassName and applies it to the cell", () => {
+      const seen = [];
+      renderOne({
+        cellClassName: (status) => {
+          seen.push(status);
+          return status.changed ? "ring-2 ring-amber-400" : "gw-unchanged";
+        },
+      });
+
+      const input = screen.getByRole("spinbutton");
+      const cell = input.closest("td");
+      expect(cell.className).toContain("gw-unchanged");
+      expect(seen.at(-1)).toMatchObject({
+        tsid: COLUMNS[0].tsid,
+        offset: 0,
+        key: KEY,
+        loadedValue: "100.5",
+        loaded: true,
+        changed: false,
+        prefilled: true,
+      });
+
+      fireEvent.change(input, { target: { value: "108" } });
+      expect(cell.className).toContain("ring-2");
+      expect(seen.at(-1)).toMatchObject({ changed: true, prefilled: false });
+    });
+
+    it("keeps default styling when cellClassName returns nothing", () => {
+      renderOne({ cellClassName: () => undefined });
+      expect(screen.getByRole("spinbutton").style.opacity).toBe("0.7");
+    });
+  });
+
   describe("per-column overrides", () => {
     // A read-only "previous value" column beside an editable entry column, both
     // pointing at the same series. The id is what keeps their cells distinct.

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -230,6 +230,21 @@ describe("CWMSInputTable nearest value loading", () => {
       expect(inputs[1].disabled).toBe(false);
     });
 
+    it("ignores a change event on a disabled cell", () => {
+      mockHook({ values: { previous_0: 100.5 } });
+      renderTable({
+        columns: REFERENCE_PAIR,
+        timeoffsets: [0],
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      // The DOM attribute stops a real user, but the component must not record
+      // an edit either if a change event reaches it anyway.
+      fireEvent.change(inputs[0], { target: { value: "777" } });
+      expect(inputs[0].value).toBe("100.5");
+    });
+
     it("lets a column override the table strategy", () => {
       mockHook();
       renderTable({
@@ -239,6 +254,65 @@ describe("CWMSInputTable nearest value loading", () => {
 
       const spec = useNearestValues.mock.calls.at(-1)[0];
       expect(spec.columns).toHaveLength(1);
+      expect(spec.columns[0].loadNearest).toBe("next");
+    });
+  });
+
+  describe("per-row overrides", () => {
+    // The transposed shape of the same idea: one row shows the last recorded
+    // value, the row beside it is for entry.
+    const REFERENCE_ROWS = [
+      { offset: 0, id: "last", label: "Last", loadNearest: "prev", disabled: true },
+      { offset: 0, id: "new", label: "New" },
+    ];
+
+    it("accepts row objects alongside plain offsets", () => {
+      mockHook({ values: { [`${COLUMNS[0].tsid}_last`]: 100.5 } });
+      renderTable({
+        columns: [COLUMNS[0]],
+        timeoffsets: REFERENCE_ROWS,
+        loadNearest: undefined,
+      });
+
+      expect(screen.queryAllByDisplayValue("100.5")).toHaveLength(1);
+    });
+
+    it("registers only the row that is not disabled", () => {
+      mockHook({ values: { [`${COLUMNS[0].tsid}_last`]: 100.5 } });
+      const { registerInput } = renderTable({
+        columns: [COLUMNS[0]],
+        timeoffsets: REFERENCE_ROWS,
+        loadNearest: undefined,
+      });
+
+      const names = new Set(registerInput.mock.calls.map((c) => c[0].name));
+      expect([...names]).toEqual([`${COLUMNS[0].tsid}_new`]);
+    });
+
+    it("keeps two rows on one instant from sharing cell state", () => {
+      mockHook({ values: { [`${COLUMNS[0].tsid}_last`]: 100.5 } });
+      renderTable({
+        columns: [COLUMNS[0]],
+        timeoffsets: REFERENCE_ROWS,
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      fireEvent.change(inputs[1], { target: { value: "42" } });
+      expect(inputs[0].value).toBe("100.5");
+      expect(inputs[1].value).toBe("42");
+    });
+
+    it("lets a column override a row", () => {
+      mockHook();
+      renderTable({
+        columns: [{ tsid: COLUMNS[0].tsid, loadNearest: "next" }],
+        timeoffsets: [{ offset: 0, loadNearest: "prev" }],
+        loadNearest: undefined,
+      });
+
+      // Most specific wins: column over row over table.
+      const spec = useNearestValues.mock.calls.at(-1)[0];
       expect(spec.columns[0].loadNearest).toBe("next");
     });
   });

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -346,6 +346,49 @@ describe("CWMSInputTable nearest value loading", () => {
       expect(inputs[0].value).toBe("12.3");
     });
 
+    it("applies readonly from a row", () => {
+      mockHook({ values: { [`${COLUMNS[0].tsid}_ref`]: 100.5 } });
+      renderTable({
+        columns: [COLUMNS[0]],
+        timeoffsets: [
+          { offset: 0, id: "ref", loadNearest: "prev", readonly: true },
+          { offset: 0, id: "entry" },
+        ],
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      expect(inputs[0].readOnly).toBe(true);
+      expect(inputs[1].readOnly).toBe(false);
+      // readonly is not disabled - the cell stays focusable and submittable.
+      expect(inputs[0].disabled).toBe(false);
+    });
+
+    // Documents why the reference pattern must use disabled, not readonly:
+    // readonly cells still register, and two cells on the same tsid+offset
+    // collide on the form's registration id.
+    it("readonly rows still register and collide on the same tsid+offset", () => {
+      mockHook({ values: { [`${COLUMNS[0].tsid}_ref`]: 100.5 } });
+      const { registerInput } = renderTable({
+        columns: [COLUMNS[0]],
+        timeoffsets: [
+          { offset: 0, id: "ref", loadNearest: "prev", readonly: true },
+          { offset: 0, id: "entry" },
+        ],
+        loadNearest: undefined,
+      });
+
+      const registered = registerInput.mock.calls.map((c) => c[0]);
+      // Both cells register...
+      expect(new Set(registered.map((r) => r.name))).toEqual(
+        new Set([`${COLUMNS[0].tsid}_ref`, `${COLUMNS[0].tsid}_entry`]),
+      );
+      // ...under the same tsid and timeOffset, which is what CWMSForm keys its
+      // registry by, so one silently replaces the other.
+      const ids = registered.map((r) => `${r.tsid}_${r.timeOffset}`);
+      expect(new Set(ids).size).toBe(1);
+    });
+
     it("lets a column override a row", () => {
       mockHook();
       renderTable({

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -389,6 +389,59 @@ describe("CWMSInputTable nearest value loading", () => {
       expect(new Set(ids).size).toBe(1);
     });
 
+    // Renders the transposed docs example verbatim and checks the three things
+    // that break when timeoffsets row objects are not normalized: headers
+    // stringify the object, both rows collapse onto one cell key, and the
+    // reference cell is editable.
+    it("renders the transposed docs example correctly", () => {
+      mockHook({ values: { "Gate 1_last": 12.3, "Gate 2_last": 4.5 } });
+      renderTable({
+        transpose: true,
+        columns: [
+          { tsid: "Gate 1", label: "Gate 1" },
+          { tsid: "Gate 2", label: "Gate 2" },
+        ],
+        timeoffsets: [
+          {
+            offset: 0,
+            id: "last",
+            label: "Last recorded",
+            loadNearest: "prev",
+            readonly: true,
+          },
+          { offset: 0, id: "new", label: "New setting" },
+        ],
+        showTimestamps: false,
+        loadNearest: undefined,
+      });
+
+      // 1. Row labels, not "Offset [object Object]s"
+      expect(screen.getByText("Last recorded")).toBeTruthy();
+      expect(screen.getByText("New setting")).toBeTruthy();
+      expect(screen.queryByText(/\[object Object\]/)).toBeNull();
+
+      const inputs = screen.getAllByRole("spinbutton");
+      expect(inputs.map((el) => el.name)).toEqual([
+        "Gate 1_last",
+        "Gate 1_new",
+        "Gate 2_last",
+        "Gate 2_new",
+      ]);
+
+      // 2. readonly is applied to the reference cells only
+      expect(inputs[0].readOnly).toBe(true);
+      expect(inputs[1].readOnly).toBe(false);
+
+      // 3. Typing in the entry cell does not leak into the reference cell
+      fireEvent.change(inputs[1], { target: { value: "77" } });
+      expect(inputs[1].value).toBe("77");
+      expect(inputs[0].value).toBe("12.3");
+
+      // ...and the read-only cell rejects an edit that reaches it
+      fireEvent.change(inputs[0], { target: { value: "999" } });
+      expect(inputs[0].value).toBe("12.3");
+    });
+
     it("lets a column override a row", () => {
       mockHook();
       renderTable({

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -155,6 +155,23 @@ describe("CWMSInputTable nearest value loading", () => {
     expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_3600`);
   });
 
+  // Reference-column pattern: a disabled table alongside an editable one shows
+  // the operator what the value was without competing to submit it. Relies on
+  // disable gating registration but not loading.
+  it("still loads values when disabled so it can act as a reference column", () => {
+    mockHook({ values: { [`${COLUMNS[0].tsid}_0`]: 100.5 } });
+    renderTable({ disable: true });
+
+    expect(screen.getByDisplayValue("100.5")).toBeTruthy();
+  });
+
+  it("does not register cells when disabled, leaving the entry table to submit", () => {
+    mockHook({ values: { [`${COLUMNS[0].tsid}_0`]: 100.5 } });
+    const { registerInput } = renderTable({ disable: true });
+
+    expect(registerInput).not.toHaveBeenCalled();
+  });
+
   it("shows value timestamp tooltip when showValueTimestamp is true", () => {
     const ts = new Date("2025-01-15T10:30:00Z").getTime();
     mockHook({

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -31,7 +31,12 @@ function renderTable(props = {}, contextOverrides = {}) {
 
   const result = render(
     <FormContext.Provider value={context}>
-      <CWMSInputTable columns={COLUMNS} timeoffsets={TIMEOFFSETS} {...props} />
+      <CWMSInputTable
+        columns={COLUMNS}
+        timeoffsets={TIMEOFFSETS}
+        loadNearest="prev"
+        {...props}
+      />
     </FormContext.Provider>,
   );
 
@@ -153,6 +158,89 @@ describe("CWMSInputTable nearest value loading", () => {
     expect(tsidOffsets).toContain(`${COLUMNS[0].tsid}_3600`);
     expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_0`);
     expect(tsidOffsets).toContain(`${COLUMNS[1].tsid}_3600`);
+  });
+
+  describe("per-column overrides", () => {
+    // A read-only "previous value" column beside an editable entry column, both
+    // pointing at the same series. The id is what keeps their cells distinct.
+    const REFERENCE_PAIR = [
+      {
+        tsid: COLUMNS[0].tsid,
+        id: "previous",
+        label: "Previous",
+        loadNearest: "prev",
+        disabled: true,
+      },
+      { tsid: COLUMNS[0].tsid, id: "entry", label: "New" },
+    ];
+
+    it("loads only the columns that opted in", () => {
+      mockHook({ values: { previous_0: 100.5, entry_0: 100.5 } });
+      renderTable({
+        columns: REFERENCE_PAIR,
+        timeoffsets: [0],
+        loadNearest: undefined,
+      });
+
+      // Reference column shows the previous value; the entry column stays empty
+      // even though it points at the same time series.
+      expect(screen.getByDisplayValue("100.5")).toBeTruthy();
+      expect(screen.queryAllByDisplayValue("100.5")).toHaveLength(1);
+    });
+
+    it("keeps two columns on one series from sharing cell state", () => {
+      mockHook({ values: { previous_0: 100.5 } });
+      renderTable({
+        columns: REFERENCE_PAIR,
+        timeoffsets: [0],
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      fireEvent.change(inputs[1], { target: { value: "42" } });
+
+      // Editing the entry column must not disturb the reference column.
+      expect(inputs[0].value).toBe("100.5");
+      expect(inputs[1].value).toBe("42");
+    });
+
+    it("registers only the column that is not disabled", () => {
+      mockHook({ values: { previous_0: 100.5 } });
+      const { registerInput } = renderTable({
+        columns: REFERENCE_PAIR,
+        timeoffsets: [0],
+        loadNearest: undefined,
+      });
+
+      // Registration re-runs as matrixData changes, so check the distinct set.
+      const names = new Set(registerInput.mock.calls.map((c) => c[0].name));
+      expect([...names]).toEqual(["entry_0"]);
+    });
+
+    it("renders a disabled column as disabled and leaves siblings editable", () => {
+      mockHook({ values: { previous_0: 100.5 } });
+      renderTable({
+        columns: REFERENCE_PAIR,
+        timeoffsets: [0],
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      expect(inputs[0].disabled).toBe(true);
+      expect(inputs[1].disabled).toBe(false);
+    });
+
+    it("lets a column override the table strategy", () => {
+      mockHook();
+      renderTable({
+        columns: [{ tsid: COLUMNS[0].tsid, loadNearest: "next" }],
+        loadNearest: "prev",
+      });
+
+      const spec = useNearestValues.mock.calls.at(-1)[0];
+      expect(spec.columns).toHaveLength(1);
+      expect(spec.columns[0].loadNearest).toBe("next");
+    });
   });
 
   // Reference-column pattern: a disabled table alongside an editable one shows

--- a/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSInputTable.test.jsx
@@ -303,6 +303,49 @@ describe("CWMSInputTable nearest value loading", () => {
       expect(inputs[1].value).toBe("42");
     });
 
+    // Mirrors the transposed docs example exactly: rows become the visual
+    // columns, so the disabled row must still render disabled cells.
+    it("disables the right cells when transposed", () => {
+      mockHook({
+        values: {
+          "Gate 1_last": 12.3,
+          "Gate 2_last": 4.5,
+        },
+      });
+      renderTable({
+        transpose: true,
+        columns: [
+          { tsid: "Gate 1", label: "Gate 1" },
+          { tsid: "Gate 2", label: "Gate 2" },
+        ],
+        timeoffsets: [
+          {
+            offset: 0,
+            id: "last",
+            label: "Last recorded",
+            loadNearest: "prev",
+            disabled: true,
+          },
+          { offset: 0, id: "new", label: "New setting" },
+        ],
+        showTimestamps: false,
+        loadNearest: undefined,
+      });
+
+      const inputs = screen.getAllByRole("spinbutton");
+      const state = inputs.map((el) => ({ name: el.name, disabled: el.disabled }));
+      expect(state).toEqual([
+        { name: "Gate 1_last", disabled: true },
+        { name: "Gate 1_new", disabled: false },
+        { name: "Gate 2_last", disabled: true },
+        { name: "Gate 2_new", disabled: false },
+      ]);
+
+      // And the disabled cell rejects an edit that reaches it anyway.
+      fireEvent.change(inputs[0], { target: { value: "999" } });
+      expect(inputs[0].value).toBe("12.3");
+    });
+
     it("lets a column override a row", () => {
       mockHook();
       renderTable({

--- a/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { FormContext } from "../../CWMSForm";
+import { CWMSSpreadsheet } from "../CWMSSpreadsheet";
+import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+
+vi.mock("../../hooks/useLoadNearestValues");
+
+const COLUMNS = [
+  { tsid: "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV", label: "Flow In" },
+  { tsid: "LWG.Elev.Inst.1Hour.0.CBT-REV", label: "Elevation" },
+];
+
+const TIMEOFFSETS = [0, 60];
+
+function renderSpreadsheet(props = {}, contextOverrides = {}) {
+  const registerInput = vi.fn(() => vi.fn());
+  const getTimestampForInput = vi.fn((offset) => {
+    const base = new Date("2025-01-15T12:00:00Z");
+    base.setTime(base.getTime() + offset * 60 * 1000);
+    return base.toISOString();
+  });
+
+  const context = {
+    registerInput,
+    getTimestampForInput,
+    office: "SWD",
+    cdaUrl: "https://water.usace.army.mil/cwms-data",
+    baseTimestamp: "2025-01-15T12:00",
+    ...contextOverrides,
+  };
+
+  const result = render(
+    <FormContext.Provider value={context}>
+      <CWMSSpreadsheet
+        columns={COLUMNS}
+        rows={2}
+        timeoffsets={TIMEOFFSETS}
+        showRowNumbers={false}
+        showColumnHeaders={false}
+        {...props}
+      />
+    </FormContext.Provider>,
+  );
+
+  return { ...result, registerInput, context };
+}
+
+function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
+  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+}
+
+describe("CWMSSpreadsheet nearest value loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("populates cells with loaded values", () => {
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 100.5,
+        [`${COLUMNS[0].tsid}_60`]: 105.2,
+        [`${COLUMNS[1].tsid}_0`]: 735.1,
+        [`${COLUMNS[1].tsid}_60`]: 735.4,
+      },
+    });
+    renderSpreadsheet();
+
+    expect(screen.getByDisplayValue("100.5")).toBeTruthy();
+    expect(screen.getByDisplayValue("105.2")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.1")).toBeTruthy();
+    expect(screen.getByDisplayValue("735.4")).toBeTruthy();
+  });
+
+  it("shows Loading... placeholder while pending", () => {
+    mockHook({ isPending: true });
+    renderSpreadsheet();
+
+    const loadingInputs = screen.getAllByPlaceholderText("Loading...");
+    expect(loadingInputs.length).toBeGreaterThan(0);
+  });
+
+  it("does not overwrite user-edited cell", () => {
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 100.5,
+      },
+    });
+    const { rerender, registerInput } = renderSpreadsheet();
+
+    const input = screen.getByDisplayValue("100.5");
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(screen.getByDisplayValue("999")).toBeTruthy();
+
+    mockHook({
+      values: {
+        [`${COLUMNS[0].tsid}_0`]: 200.0,
+      },
+    });
+    rerender(
+      <FormContext.Provider
+        value={{
+          registerInput,
+          getTimestampForInput: vi.fn((offset) => {
+            const base = new Date("2025-01-15T12:00:00Z");
+            base.setTime(base.getTime() + offset * 60 * 1000);
+            return base.toISOString();
+          }),
+          office: "SWD",
+          cdaUrl: "https://water.usace.army.mil/cwms-data",
+          baseTimestamp: "2025-01-15T12:00",
+        }}
+      >
+        <CWMSSpreadsheet
+          columns={COLUMNS}
+          rows={2}
+          timeoffsets={TIMEOFFSETS}
+          showRowNumbers={false}
+          showColumnHeaders={false}
+        />
+      </FormContext.Provider>,
+    );
+
+    expect(screen.getByDisplayValue("999")).toBeTruthy();
+    expect(screen.queryByDisplayValue("200")).toBeNull();
+  });
+
+  it("shows value timestamp tooltip when showValueTimestamp is true", () => {
+    const ts = new Date("2025-01-15T10:30:00Z").getTime();
+    mockHook({
+      values: { [`${COLUMNS[0].tsid}_0`]: 100.5 },
+      timestamps: { [`${COLUMNS[0].tsid}_0`]: ts },
+    });
+    renderSpreadsheet({ showValueTimestamp: true });
+
+    const input = screen.getByDisplayValue("100.5");
+    expect(input.title).toContain("Value from:");
+  });
+
+  it("reset restores loaded value", () => {
+    mockHook({
+      values: { [`${COLUMNS[0].tsid}_0`]: 42.5 },
+    });
+    const { registerInput } = renderSpreadsheet();
+
+    expect(screen.getByDisplayValue("42.5")).toBeTruthy();
+
+    const input = screen.getByDisplayValue("42.5");
+    fireEvent.change(input, { target: { value: "999" } });
+    expect(screen.getByDisplayValue("999")).toBeTruthy();
+
+    // The spreadsheet registers cells with name like "rowIdx_colIdx"
+    // Column 0 with timeoffsets has a time column prepended, so data col 0 is at col index 1
+    const registrations = registerInput.mock.calls.map((c) => c[0]);
+    const cellReg = registrations.find(
+      (r) => r.tsid === COLUMNS[0].tsid && r.timeOffset === 0,
+    );
+
+    act(() => {
+      cellReg.reset();
+    });
+
+    expect(screen.getByDisplayValue("42.5")).toBeTruthy();
+  });
+
+  it("passes strategy to hook", () => {
+    mockHook();
+    renderSpreadsheet({ loadNearest: "next" });
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: "next" }),
+    );
+  });
+
+  it("disables loading when no office is set", () => {
+    mockHook();
+    renderSpreadsheet({}, { office: undefined });
+
+    expect(useLoadNearestValues).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { FormContext } from "../../CWMSForm";
 import { CWMSSpreadsheet } from "../CWMSSpreadsheet";
-import useLoadNearestValues from "../../hooks/useLoadNearestValues";
+import { useNearestValues } from "../../hooks/useNearestValueStore";
 
-vi.mock("../../hooks/useLoadNearestValues");
+vi.mock("../../hooks/useNearestValueStore");
 
 const COLUMNS = [
   { tsid: "LWG.Flow-In.Ave.1Hour.1Hour.CBT-REV", label: "Flow In" },
@@ -46,7 +46,7 @@ function renderSpreadsheet(props = {}, contextOverrides = {}) {
 }
 
 function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
-  useLoadNearestValues.mockReturnValue({ values, timestamps, isPending });
+  useNearestValues.mockReturnValue({ values, timestamps, isPending });
 }
 
 describe("CWMSSpreadsheet nearest value loading", () => {
@@ -166,16 +166,18 @@ describe("CWMSSpreadsheet nearest value loading", () => {
     mockHook();
     renderSpreadsheet({ loadNearest: "next" });
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ strategy: "next" }),
     );
   });
 
-  it("disables loading when no office is set", () => {
+  // Whether a fetch actually happens is the store's call (it needs an office);
+  // the component's only job is to declare the need when loadNearest is set.
+  it("does not declare a need when loadNearest is unset", () => {
     mockHook();
-    renderSpreadsheet({}, { office: undefined });
+    renderSpreadsheet({ loadNearest: undefined });
 
-    expect(useLoadNearestValues).toHaveBeenCalledWith(
+    expect(useNearestValues).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: false }),
     );
   });

--- a/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
+++ b/lib/components/data/forms/inputs/__tests__/CWMSSpreadsheet.nearestValue.test.jsx
@@ -49,6 +49,113 @@ function mockHook({ values = {}, timestamps = {}, isPending = false } = {}) {
   useNearestValues.mockReturnValue({ values, timestamps, isPending });
 }
 
+describe("CWMSSpreadsheet row objects and change styling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const TSID = COLUMNS[0].tsid;
+
+  it("accepts row objects in timeoffsets", () => {
+    mockHook({ values: { [`${TSID}_first`]: 100.5 } });
+    renderSpreadsheet({
+      columns: [COLUMNS[0]],
+      rows: 1,
+      timeoffsets: [{ offset: 0, id: "first" }],
+      loadNearest: "prev",
+    });
+
+    expect(screen.getByDisplayValue("100.5")).toBeTruthy();
+    // Regression: an un-normalized row object stringifies into the cell key.
+    expect(screen.queryByDisplayValue(/\[object Object\]/)).toBeNull();
+  });
+
+  it("rounds loaded values to precision, like the table does", () => {
+    mockHook({ values: { [`${TSID}_0`]: 42.56789 } });
+    renderSpreadsheet({
+      columns: [{ ...COLUMNS[0], precision: 1 }],
+      rows: 1,
+      timeoffsets: [0],
+      loadNearest: "prev",
+    });
+
+    expect(screen.getByDisplayValue("42.6")).toBeTruthy();
+  });
+
+  it("dims a prefilled cell and emboldens a changed one", () => {
+    mockHook({ values: { [`${TSID}_0`]: 100.5 } });
+    renderSpreadsheet({
+      columns: [COLUMNS[0]],
+      rows: 1,
+      timeoffsets: [0],
+      loadNearest: "prev",
+    });
+
+    const input = screen.getByDisplayValue("100.5");
+    expect(input.style.opacity).toBe("0.7");
+    expect(input.style.fontWeight).toBe("");
+
+    fireEvent.change(input, { target: { value: "108" } });
+    expect(input.style.fontWeight).toBe("600");
+    expect(input.style.opacity).toBe("");
+  });
+
+  it("treats a cell typed back to the loaded value as unchanged", () => {
+    mockHook({ values: { [`${TSID}_0`]: 100.5 } });
+    renderSpreadsheet({
+      columns: [COLUMNS[0]],
+      rows: 1,
+      timeoffsets: [0],
+      loadNearest: "prev",
+    });
+
+    const input = screen.getByDisplayValue("100.5");
+    fireEvent.change(input, { target: { value: "108" } });
+    fireEvent.change(input, { target: { value: "100.5" } });
+    expect(input.style.opacity).toBe("0.7");
+    expect(input.style.fontWeight).toBe("");
+  });
+
+  it("passes cell status to cellClassName and applies it to the cell", () => {
+    const seen = [];
+    mockHook({ values: { [`${TSID}_0`]: 100.5 } });
+    renderSpreadsheet({
+      columns: [COLUMNS[0]],
+      rows: 1,
+      timeoffsets: [0],
+      loadNearest: "prev",
+      cellClassName: (status) => {
+        seen.push(status);
+        return status.changed ? "is-changed" : "is-prefilled";
+      },
+    });
+
+    const input = screen.getByDisplayValue("100.5");
+    expect(input.closest("td").className).toContain("is-prefilled");
+    expect(seen.at(-1)).toMatchObject({
+      tsid: TSID,
+      offset: 0,
+      loadedValue: "100.5",
+      loaded: true,
+      changed: false,
+      prefilled: true,
+    });
+  });
+
+  it("can be turned off with highlightChanged", () => {
+    mockHook({ values: { [`${TSID}_0`]: 100.5 } });
+    renderSpreadsheet({
+      columns: [COLUMNS[0]],
+      rows: 1,
+      timeoffsets: [0],
+      loadNearest: "prev",
+      highlightChanged: false,
+    });
+
+    expect(screen.getByDisplayValue("100.5").style.opacity).toBe("");
+  });
+});
+
 describe("CWMSSpreadsheet nearest value loading", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -25,7 +25,12 @@ import {
 } from "./components/data/forms/hooks/useCwmsFormSubmit";
 import useLoadNearestValues, {
   selectNearestValue,
+  useNearestSeriesData,
 } from "./components/data/forms/hooks/useLoadNearestValues";
+import {
+  useNearestValues,
+  useNearestValueStore,
+} from "./components/data/forms/hooks/useNearestValueStore";
 import {
   showSuccessToast,
   showErrorToast,
@@ -119,6 +124,9 @@ export {
   useFormValidation,
   useSubmissionFormatter,
   useLoadNearestValues,
+  useNearestSeriesData,
+  useNearestValues,
+  useNearestValueStore,
   selectNearestValue,
   // Toast utilities
   showSuccessToast,

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -23,6 +23,9 @@ import {
   useFormValidation,
   useSubmissionFormatter,
 } from "./components/data/forms/hooks/useCwmsFormSubmit";
+import useLoadNearestValues, {
+  selectNearestValue,
+} from "./components/data/forms/hooks/useLoadNearestValues";
 import {
   showSuccessToast,
   showErrorToast,
@@ -115,6 +118,8 @@ export {
   useCwmsFormSubmit,
   useFormValidation,
   useSubmissionFormatter,
+  useLoadNearestValues,
+  selectNearestValue,
   // Toast utilities
   showSuccessToast,
   showErrorToast,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,9 +1617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1637,9 +1634,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,9 +1651,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,9 +1668,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1697,9 +1685,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1717,9 +1702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5907,9 +5889,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5931,9 +5910,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5955,9 +5931,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5979,9 +5952,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
fixes #215

Added per cell loading of the nearest values according the the strategy chose, this fetching is made and conducted by a single orchestrator to handle over lapping request.

On submit store the changes locally so that the correct data can be rendered even when the cda cache is stale.

Add hooks to detect failed fetching of prev values and when values have been change from the loaded prev value.

Added timeseries row overrides for the cwms input table and spreadsheet.